### PR TITLE
Smooth camera transition when following user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
 ## Unreleased
- - Removed `updateCourseTracking` from `layoutSubviews()`
- - Set `self.cameraEdgeInsets` for each `setCamera` in `updateCourseTracking()`
+ - Removed setCamera() from updateCourseTracking()
+ - Added setCamera() to progressDidChange()
 
 ## v2.0.0 (May 23, 2023)
  - Upgrade minimum iOS version from 11.0 to 12.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## Unreleased
+ - Removed `updateCourseTracking` from `layoutSubviews()`
+ - Set `self.cameraEdgeInsets` for each `setCamera` in `updateCourseTracking()`
+
 ## v2.0.0 (May 23, 2023)
  - Upgrade minimum iOS version from 11.0 to 12.0.
  - Upgraded dependencies to support iOS 12.0

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -244,15 +244,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         addSubview(imageView)
     }
     
-    open override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        //If the map is in tracking mode, make sure we update the camera after the layout pass.
-        if (tracksUserCourse) {
-            updateCourseTracking(location: userLocationForCourseTracking, camera:self.camera, animated: false)
-        }
-    }
-    
     open override func anchorPoint(forGesture gesture: UIGestureRecognizer) -> CGPoint {
         if tracksUserCourse {
             return userAnchorPoint
@@ -342,11 +333,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
         
         if tracksUserCourse {
-            let point = userAnchorPoint
-            let padding = UIEdgeInsets(top: point.y, left: point.x, bottom: bounds.height - point.y, right: bounds.width - point.x)
-            let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, fromDistance: altitude, pitch: 45, heading: location.course)
+            let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45.0, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear) : nil
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
+            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: self.cameraEdgeInsets, completionHandler: nil)
         }
         if !tracksUserCourse || userAnchorPoint != userCourseView?.center ?? userAnchorPoint {
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -244,6 +244,15 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         addSubview(imageView)
     }
     
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        //If the map is in tracking mode, make sure we update the camera after the layout pass.
+        if (tracksUserCourse) {
+            updateCourseTracking(location: userLocationForCourseTracking, camera:self.camera, animated: false)
+        }
+    }
+    
     open override func anchorPoint(forGesture gesture: UIGestureRecognizer) -> CGPoint {
         if tracksUserCourse {
             return userAnchorPoint
@@ -335,7 +344,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         if tracksUserCourse {
             let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45.0, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear) : nil
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: self.cameraEdgeInsets, completionHandler: nil)
+            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: UIEdgeInsets.zero, completionHandler: nil)
         }
         if !tracksUserCourse || userAnchorPoint != userCourseView?.center ?? userAnchorPoint {
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -288,6 +288,12 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     @objc func progressDidChange(_ notification: Notification) {
         guard tracksUserCourse else { return }
         
+        if let location = userLocationForCourseTracking {
+            let newCamera = MGLMapCamera(lookingAtCenter: location.coordinate, acrossDistance: altitude, pitch: 45, heading: location.course)
+            let function: CAMediaTimingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
+            setCamera(newCamera, withDuration: 1, animationTimingFunction: function, edgePadding: UIEdgeInsets.zero, completionHandler: nil)
+        }
+        
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
         
         let stepProgress = routeProgress.currentLegProgress.currentStepProgress
@@ -341,11 +347,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
         
-        if tracksUserCourse {
-            let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45.0, heading: location.course)
-            let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear) : nil
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: UIEdgeInsets.zero, completionHandler: nil)
-        }
         if !tracksUserCourse || userAnchorPoint != userCourseView?.center ?? userAnchorPoint {
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
                 self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)


### PR DESCRIPTION
Fixes #1 

The func `layoutSubviews` is called each time the mapView changes, causing `updateCourseTracking`
 called in a too high frequency. Also setting the `edgePadding` in `setCamera()` to `self.cameraEdgeInsets` instead of adding to high padding values will remove the jerky map transitions.

By setting a custom camera in the Example App you can add custom `UIEdgeInsets`.
Even without the custom camera the Example App will work smoothly.

- Removed updateCourseTracking from layoutSubviews()
- Set self.cameraEdgeInsets for each setCamera in updateCourseTracking()

UPDATE:

Removing the camera updates from `updateCourseTracking` reduces the call about 30-40 times a second. The example App should run now without the jerky map animations. Also works fine when setting a custom camera.

- Added layoutSubviews() again
- Removed `setCamera()` from `updateCourseTracking()`
- Added `setCamera()` to `progressDidChange()`