### PR TITLE
Only snap location if user is close to the route line

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,10 +1,10 @@
 name: iOS starter workflow
 
 on:
-    push:
-        branches:
-            - master
-    pull_request:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,10 @@
 name: iOS starter workflow
 
-on: [pull_request]
+on:
+    push:
+        branches:
+            - master
+    pull_request:
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Add option to overwrite camera update via NavigationMapViewCourseTrackingDelegate#updateCamera
  - Remove MapboxVoiceController and Mapbox Speech dependency. If you would like to use MapboxSpeech, you can copy the deleted MapboxVoiceController into your project.
  - Updated MapLibre Native dependency to ios-v6.0.0 (https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.0.0). Implementers need to change the prefix MGL to MLN for all MapLibre Native classes that are referenced.
+ - Only snap location to route if the location is within the `RouteControllerUserLocationSnappingDistance`
 
 ## v2.0.0 (May 23, 2023)
  - Upgrade minimum iOS version from 11.0 to 12.0.

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -97,7 +97,7 @@ public var RouteSnappingMinimumHorizontalAccuracy: CLLocationAccuracy = 20.0
 public var RouteControllerMinNumberOfInCorrectCourses: Int = 4
 
 /**
- Given a location update, the `horizontalAccuracy` is used to figure out how many consective location updates to wait before rerouting due to consecutive incorrect course updates.
+ Given a location update, the `horizontalAccuracy` is used to figure out how many consecutive location updates to wait before rerouting due to consecutive incorrect course updates.
  */
 public var RouteControllerIncorrectCourseMultiplier: Int = 4
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -250,6 +250,9 @@ open class RouteController: NSObject, Router {
         userSnapToStepDistanceFromManeuver = Polyline(coordinates).distance(from: coordinate)
     }
 
+    /**
+     If the user is close to an intersection, the tolerance will be lower, otherwise it will be RouteControllerMaximumDistanceBeforeRecalculating
+     */
     @objc public var reroutingTolerance: CLLocationDistance {
         guard let intersections = routeProgress.currentLegProgress.currentStepProgress.intersectionsIncludingUpcomingManeuverIntersection else { return RouteControllerMaximumDistanceBeforeRecalculating }
         guard let userLocation = rawLocation else { return RouteControllerMaximumDistanceBeforeRecalculating }
@@ -441,7 +444,7 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     /**
-     Monitors the user's course to see if it is consistantly moving away from what we expect the course to be at a given point.
+     Monitors the user's course to see if it is consistently moving away from what we expect the course to be at a given point.
      */
     func userCourseIsOnRoute(_ location: CLLocation) -> Bool {
         let nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
@@ -451,7 +454,7 @@ extension RouteController: CLLocationManagerDelegate {
 
         if movementsAwayFromRoute >= max(RouteControllerMinNumberOfInCorrectCourses, maxUpdatesAwayFromRouteGivenAccuracy)  {
             return false
-        } else if location.shouldSnap(toRouteWith: calculatedCourseForLocationOnStep) {
+        } else if location.shouldSnapCourse(toRouteWith: calculatedCourseForLocationOnStep) {
             movementsAwayFromRoute = 0
         } else {
             movementsAwayFromRoute += 1
@@ -472,11 +475,15 @@ extension RouteController: CLLocationManagerDelegate {
             return true
         }
 
+        // If user is close to an intersection, the radius will be lower, so reroutes will fire easier.
         let radius = max(reroutingTolerance, RouteControllerManeuverZoneRadius)
+        
+        // This checks all coordinates of the step, if user is close to the step, they on the route
         let isCloseToCurrentStep = location.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
 
+        // If the user is either close to the current step or at least driving in the right direction, we assume the user is on route
         guard !isCloseToCurrentStep || !userCourseIsOnRoute(location) else { return true }
-
+        
         // Check and see if the user is near a future step.
         guard let nearestStep = routeProgress.currentLegProgress.closestStep(to: location.coordinate) else {
             return false

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -72,11 +72,11 @@ class LocationTests: XCTestCase {
         
         let initialHeadingOnFirstStep = progress.currentLegProgress.currentStepProgress.step.finalHeading!
         
-        XCTAssertTrue(firstLocation.shouldSnap(toRouteWith: initialHeadingOnFirstStep), "Should snap")
+        XCTAssertTrue(firstLocation.shouldSnapCourse(toRouteWith: initialHeadingOnFirstStep), "Should snap")
         
         let differentCourseAndAccurateLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: 0, speed: 10, timestamp: Date())
         
-        XCTAssertFalse(differentCourseAndAccurateLocation.shouldSnap(toRouteWith: initialHeadingOnFirstStep), "Should not snap when user course is different, the location is accurate and moving")
+        XCTAssertFalse(differentCourseAndAccurateLocation.shouldSnapCourse(toRouteWith: initialHeadingOnFirstStep), "Should not snap when user course is different, the location is accurate and moving")
     }
     
 }

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -5,7 +5,9 @@ import Turf
 
 let response = Fixture.JSONFromFileNamed(name: "routeWithInstructions")
 let jsonRoute = (response["routes"] as! [AnyObject]).first as! [String : Any]
+// -122.413165,37.795042
 let waypoint1 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165))
+// -122.433378,37.7727
 let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
 let directions = Directions(accessToken: "pk.feedCafeDeadBeefBadeBede")
 let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], options: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
@@ -38,9 +40,15 @@ class MapboxCoreNavigationTests: XCTestCase {
         }
     }
     
+    func makeLocation(latitude: Double, longitude: Double, course: CLLocationDirection) -> CLLocation {
+        return CLLocation(coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: course, speed: 10, timestamp: Date())
+    }
+    
     func testNewStep() {
         route.accessToken = "foo"
-        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.78895, longitude: -122.42543), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        let coordOnStep1 = route.legs[0].steps[1].coordinates![5]
+        let location = makeLocation(latitude: coordOnStep1.latitude, longitude: coordOnStep1.longitude, course: 250)
+        
         let locationManager = ReplayLocationManager(locations: [location, location])
         navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
         
@@ -49,7 +57,7 @@ class MapboxCoreNavigationTests: XCTestCase {
             
             let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
             
-            return routeProgress?.currentLegProgress.stepIndex == 2
+            return routeProgress?.currentLegProgress.stepIndex == 1
         }
         
         navigation.resume()
@@ -61,10 +69,13 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testJumpAheadToLastStep() {
         route.accessToken = "foo"
-        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.77386, longitude: -122.43085), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        let coordOnLastStep = route.legs[0].steps[6].coordinates![5]
+        let location = makeLocation(latitude: coordOnLastStep.latitude, longitude: coordOnLastStep.longitude, course: 171)
         
         let locationManager = ReplayLocationManager(locations: [location, location])
         navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        // Start at step 5, if you want to skip ahead to 6
+        //navigation.routeProgress.currentLegProgress.stepIndex = 5
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -74,8 +74,6 @@ class MapboxCoreNavigationTests: XCTestCase {
         
         let locationManager = ReplayLocationManager(locations: [location, location])
         navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
-        // Start at step 5, if you want to skip ahead to 6
-        //navigation.routeProgress.currentLegProgress.stepIndex = 5
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -183,7 +183,7 @@ class RouteControllerTests: XCTestCase {
 
         // The course should not be the interpolated course, rather the raw course.
         XCTAssertEqual(directionToStart, navigation.location!.course, "The course should be the raw course and not an interpolated course")
-        XCTAssertFalse(facingTowardsStartLocation.shouldSnap(toRouteWith: facingTowardsStartLocation.interpolatedCourse(along: navigation.routeProgress.currentLegProgress.nearbyCoordinates)!, distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
+        XCTAssertFalse(facingTowardsStartLocation.shouldSnapCourse(toRouteWith: facingTowardsStartLocation.interpolatedCourse(along: navigation.routeProgress.currentLegProgress.nearbyCoordinates)!, distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
     }
 
     func testLocationShouldUseHeading() {


### PR DESCRIPTION
This PR will change the snapping logic. Right now the location will be snapped on the route line, no matter how far a user is away from the route line, as long as the user is facing into the somewhat right direction.

This PR make sure the snapping only happens if the user is close to the route line and faces in the right directions.

This PR still needs a bit more real life testing, first quick tests look good.

@ianthetechie if you have the time, a review would be very welcome.