### PR TITLE
chore: updated MapLibre Native dependency to use the ios-v6.0.0 versi…

### DIFF
--- a/Examples/Objective-C/AppDelegate.m
+++ b/Examples/Objective-C/AppDelegate.m
@@ -1,6 +1,6 @@
 #import "AppDelegate.h"
 
-@import Mapbox;
+@import MapLibre;
 
 @interface AppDelegate ()
 

--- a/Examples/Objective-C/Base.lproj/Main.storyboard
+++ b/Examples/Objective-C/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,10 +19,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A3N-JT-loC" customClass="MGLMapView">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A3N-JT-loC" customClass="MLNMapView">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Sl-bV-xyU">
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Sl-bV-xyU">
                                         <rect key="frame" x="132" y="615" width="111" height="30"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.75" colorSpace="calibratedRGB"/>
                                         <state key="normal" title="Start Navigation"/>
@@ -33,7 +31,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Long press map to select a route" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hk0-SM-2Wl">
-                                        <rect key="frame" x="62" y="619" width="251" height="21"/>
+                                        <rect key="frame" x="63" y="619" width="249" height="21"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.75" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -4,10 +4,10 @@
 @import MapboxCoreNavigation;
 @import MapboxDirections;
 @import MapboxNavigation;
-@import Mapbox;
+@import MapLibre;
 
 @interface ViewController () <AVSpeechSynthesizerDelegate>
-@property (nonatomic, weak) IBOutlet MGLMapView *mapView;
+@property (nonatomic, weak) IBOutlet MLNMapView *mapView;
 @property (weak, nonatomic) IBOutlet UIButton *toggleNavigationButton;
 @property (weak, nonatomic) IBOutlet UILabel *howToBeginLabel;
 @property (nonatomic, assign) CLLocationCoordinate2D destination;
@@ -22,7 +22,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
-    self.mapView.userTrackingMode = MGLUserTrackingModeFollow;
+    self.mapView.userTrackingMode = MLNUserTrackingModeFollow;
     
     self.lengthFormatter = [[NSLengthFormatter alloc] init];
     self.lengthFormatter.unitStyle = NSFormattingUnitStyleShort;
@@ -94,7 +94,7 @@
         CLLocationCoordinate2D *routeCoordinates = malloc(route.coordinateCount * sizeof(CLLocationCoordinate2D));
         [route getCoordinates:routeCoordinates];
         
-        MGLPolyline *polyline = [MGLPolyline polylineWithCoordinates:routeCoordinates count:route.coordinateCount];
+        MLNPolyline *polyline = [MLNPolyline polylineWithCoordinates:routeCoordinates count:route.coordinateCount];
         
         [self.mapView addAnnotation:polyline];
         [self.mapView setVisibleCoordinates:routeCoordinates count:route.coordinateCount edgePadding:UIEdgeInsetsZero animated:YES];

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -1,15 +1,15 @@
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation
-import Mapbox
+import MapLibre
 import CoreLocation
 import AVFoundation
 import MapboxDirections
 import Turf
 
-class CustomViewController: UIViewController, MGLMapViewDelegate {
+class CustomViewController: UIViewController, MLNMapViewDelegate {
 
-    var destination: MGLPointAnnotation!
+    var destination: MLNPointAnnotation!
     let directions = Directions.shared
     var routeController: RouteController!
     var simulateLocation = false
@@ -69,7 +69,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         NotificationCenter.default.removeObserver(self, name: .routeControllerDidPassVisualInstructionPoint, object: nil)
     }
 
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         self.mapView.showRoutes([routeController.routeProgress.route])
     }
 
@@ -167,7 +167,7 @@ extension CustomViewController: NavigationMapViewCourseTrackingDelegate {
 
     func updateCamera(_ mapView: NavigationMapView, location: CLLocation, routeProgress: RouteProgress) -> Bool{
         
-        let newCamera = MGLMapCamera(lookingAtCenter: location.coordinate, acrossDistance: 750, pitch: 5, heading: location.course)
+        let newCamera = MLNMapCamera(lookingAtCenter: location.coordinate, acrossDistance: 750, pitch: 5, heading: location.course)
         let function: CAMediaTimingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
         mapView.setCamera(newCamera, withDuration: 1, animationTimingFunction: function, edgePadding: UIEdgeInsets.zero, completionHandler: nil)
         

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapLibre
 import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
@@ -9,7 +10,7 @@ private typealias RouteRequestSuccess = (([Route]) -> Void)
 private typealias RouteRequestFailure = ((NSError) -> Void)
 
 
-class ViewController: UIViewController, MGLMapViewDelegate {
+class ViewController: UIViewController, MLNMapViewDelegate {
     
     // MARK: - IBOutlets
     @IBOutlet weak var longPressHintView: UIView!
@@ -229,7 +230,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
 
         customViewController.userRoute = route
 
-        let destination = MGLPointAnnotation()
+        let destination = MLNPointAnnotation()
         destination.coordinate = route.coordinates!.last!
         customViewController.destination = destination
         customViewController.simulateLocation = simulationButton.isSelected
@@ -274,11 +275,11 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         mapView.addGestureRecognizer(singleTap)
     }
 
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         self.mapView?.localizeLabels()
         
         if let routes = routes, let currentRoute = routes.first, let coords = currentRoute.coordinates {
-            mapView.setVisibleCoordinateBounds(MGLPolygon(coordinates: coords, count: currentRoute.coordinateCount).overlayBounds, animated: false)
+            mapView.setVisibleCoordinateBounds(MLNPolygon(coordinates: coords, count: currentRoute.coordinateCount).overlayBounds, animated: false)
             self.mapView?.showRoutes(routes)
             self.mapView?.showWaypoints(currentRoute)
         }

--- a/MapboxCoreNavigationTests/BridgingTests.m
+++ b/MapboxCoreNavigationTests/BridgingTests.m
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
 #import "MapboxCoreNavigationTests-Swift.h"
-@import Mapbox;
+@import MapLibre;
 @import MapboxCoreNavigation;
 @import MapboxDirections;
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		351030111F54B72000E3B7E7 /* route-for-lane-testing.json in Resources */ = {isa = PBXBuildFile; fileRef = 351030101F54B72000E3B7E7 /* route-for-lane-testing.json */; };
 		351174F41EF1C0530065E248 /* ReplayLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351174F31EF1C0530065E248 /* ReplayLocationManager.swift */; };
 		351927361F0FA072003A702D /* ScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351927351F0FA072003A702D /* ScreenCapture.swift */; };
-		351BEBF11E5BCC63006FE110 /* MGLMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */; };
+		351BEBF11E5BCC63006FE110 /* MLNMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBDF1E5BCC63006FE110 /* MLNMapView.swift */; };
 		351BEBF21E5BCC63006FE110 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBE01E5BCC63006FE110 /* Style.swift */; };
 		351BEBF61E5BCC63006FE110 /* RouteMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */; };
 		351BEBFC1E5BCC63006FE110 /* NavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */; };
@@ -61,7 +61,7 @@
 		35379D0221480E1300FD402E /* CarPlayManager+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35379D0121480E1300FD402E /* CarPlayManager+Search.swift */; };
 		35379D0321480E5700FD402E /* RecentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352C35BF2134958F00D77796 /* RecentItem.swift */; };
 		353AA5601FCEF583009F0384 /* StyleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353AA55F1FCEF583009F0384 /* StyleManager.swift */; };
-		353E3C8F20A3501C00FD1789 /* MGLStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E3C8E20A3501C00FD1789 /* MGLStyle.swift */; };
+		353E3C8F20A3501C00FD1789 /* MLNStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E3C8E20A3501C00FD1789 /* MLNStyle.swift */; };
 		353E68FC1EF0B7F8007B2AE5 /* NavigationLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */; };
 		353E68FE1EF0B985007B2AE5 /* BundleAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E68FD1EF0B985007B2AE5 /* BundleAdditions.swift */; };
 		353E69041EF0C4E5007B2AE5 /* SimulatedLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */; };
@@ -122,7 +122,7 @@
 		35D428291FA0B61F00176028 /* InstructionsBannerViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D428281FA0B61F00176028 /* InstructionsBannerViewLayout.swift */; };
 		35D4282B1FA0DF1D00176028 /* MapboxNavigation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		35D457A71E2D253100A89946 /* MBRouteController.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D457A61E2D253100A89946 /* MBRouteController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */; };
+		35D825FC1E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D825FA1E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.m */; };
 		35D825FE1E6A2EC60088F83B /* MapboxNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35DA85791FC45787004092EC /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DA85781FC45787004092EC /* StatusView.swift */; };
 		35DC585D1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC585C1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift */; };
@@ -143,6 +143,9 @@
 		3EA93DC5BA00B5DFCBE7BAC3 /* RouteControllerDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */; };
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
 		64847A041F04629D003F3A69 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64847A031F04629D003F3A69 /* Feedback.swift */; };
+		7170CCBA2B6D2AE00054DF8E /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 7170CCB92B6D2AE00054DF8E /* MapLibre */; };
+		7170CCBC2B6D2AF10054DF8E /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 7170CCBB2B6D2AF10054DF8E /* MapLibre */; };
+		7170CCBE2B6D2B570054DF8E /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 7170CCBD2B6D2B570054DF8E /* MapLibre */; };
 		8D07C5A820B612310093D779 /* EmptyStyle.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D07C5A720B612310093D779 /* EmptyStyle.json */; };
 		8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */; };
 		8D24A2F820409A890098CBF8 /* CGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F720409A890098CBF8 /* CGSize.swift */; };
@@ -178,10 +181,7 @@
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09D21DEF636C00BE3C5C /* Fixture.swift */; };
 		C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53208AA1E81FFB900910266 /* NavigationMapView.swift */; };
-		C533529B278DD8ED003DEC63 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C533529A278DD8ED003DEC63 /* Mapbox */; };
 		C533529F278DD90B003DEC63 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C533529E278DD90B003DEC63 /* Mapbox */; };
-		C53352A3278DD917003DEC63 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C53352A2278DD917003DEC63 /* Mapbox */; };
-		C53352A7278DD925003DEC63 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C53352A6278DD925003DEC63 /* Mapbox */; };
 		C5381F02204E03B600A5493E /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5381F01204E03B600A5493E /* UIDevice.swift */; };
 		C5381F03204E052A00A5493E /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5381F01204E03B600A5493E /* UIDevice.swift */; };
 		C5387A9D1F8FDB13000D2E93 /* routeWithInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = C5387A9C1F8FDB13000D2E93 /* routeWithInstructions.json */; };
@@ -254,7 +254,7 @@
 		C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57491DE1FACC42F006F97BC /* CGPoint.swift */; };
 		C578DA081EFD0FFF0052079F /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C578DA071EFD0FFF0052079F /* ProcessInfo.swift */; };
 		C57AD98A20EAA39A0087B24B /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = C57AD98920EAA39A0087B24B /* Entitlements.plist */; };
-		C58159011EA6D02700FC6C3D /* MGLVectorTileSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58159001EA6D02700FC6C3D /* MGLVectorTileSource.swift */; };
+		C58159011EA6D02700FC6C3D /* MLNVectorTileSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58159001EA6D02700FC6C3D /* MLNVectorTileSource.swift */; };
 		C582BA2C2073E77E00647DAA /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582BA2B2073E77E00647DAA /* StringTests.swift */; };
 		C582FD5F203626E900A9086E /* CLLocationDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582FD5E203626E900A9086E /* CLLocationDirection.swift */; };
 		C58822001FB0F0D7008B0A2D /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58821FF1FB0F0D7008B0A2D /* Error.swift */; };
@@ -291,7 +291,7 @@
 		C5F4D21920DC468B0059FABF /* CongestionLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F4D21820DC468B0059FABF /* CongestionLevel.swift */; };
 		C5FFAC1520D96F5C009E7F98 /* CarPlayNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FFAC1420D96F5B009E7F98 /* CarPlayNavigationViewController.swift */; };
 		D72CC42C2451A2F800238549 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72CC42B2451A2F800238549 /* ConfigManager.swift */; };
-		DA23C9611F4FC05C00BA9522 /* MGLMapView+MGLNavigationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA23C9611F4FC05C00BA9522 /* MLNMapView+MLNNavigationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825F91E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAB2CCE71DF7AFDF001B2FE1 /* dc-line.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DAB2CCE61DF7AFDE001B2FE1 /* dc-line.geojson */; };
@@ -515,7 +515,7 @@
 		351927351F0FA072003A702D /* ScreenCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenCapture.swift; sourceTree = "<group>"; };
 		351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		351BEBDA1E5BCC28006FE110 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLMapView.swift; sourceTree = "<group>"; };
+		351BEBDF1E5BCC63006FE110 /* MLNMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLNMapView.swift; sourceTree = "<group>"; };
 		351BEBE01E5BCC63006FE110 /* Style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RouteMapViewController.swift; sourceTree = "<group>"; };
 		351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NavigationViewController.swift; sourceTree = "<group>"; };
@@ -550,7 +550,7 @@
 		35379CFB21480BFB00FD402E /* AppDelegate+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CarPlay.swift"; sourceTree = "<group>"; };
 		35379D0121480E1300FD402E /* CarPlayManager+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarPlayManager+Search.swift"; sourceTree = "<group>"; };
 		353AA55F1FCEF583009F0384 /* StyleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleManager.swift; sourceTree = "<group>"; };
-		353E3C8E20A3501C00FD1789 /* MGLStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLStyle.swift; sourceTree = "<group>"; };
+		353E3C8E20A3501C00FD1789 /* MLNStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLNStyle.swift; sourceTree = "<group>"; };
 		353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManager.swift; sourceTree = "<group>"; };
 		353E68FD1EF0B985007B2AE5 /* BundleAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleAdditions.swift; sourceTree = "<group>"; };
 		353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedLocationManager.swift; sourceTree = "<group>"; };
@@ -622,8 +622,8 @@
 		35CF34B01F0A733200C2692E /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		35D428281FA0B61F00176028 /* InstructionsBannerViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsBannerViewLayout.swift; sourceTree = "<group>"; };
 		35D457A61E2D253100A89946 /* MBRouteController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBRouteController.h; sourceTree = "<group>"; };
-		35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLMapView+MGLNavigationAdditions.h"; sourceTree = "<group>"; };
-		35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLMapView+MGLNavigationAdditions.m"; sourceTree = "<group>"; };
+		35D825F91E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MLNMapView+MLNNavigationAdditions.h"; sourceTree = "<group>"; };
+		35D825FA1E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MLNMapView+MLNNavigationAdditions.m"; sourceTree = "<group>"; };
 		35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapboxNavigation.h; sourceTree = "<group>"; };
 		35DA85781FC45787004092EC /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		35DC585C1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsBannerViewIntegrationTests.swift; sourceTree = "<group>"; };
@@ -704,7 +704,7 @@
 		C57491DE1FACC42F006F97BC /* CGPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CGPoint.swift; path = ../MapboxNavigation/CGPoint.swift; sourceTree = "<group>"; };
 		C578DA071EFD0FFF0052079F /* ProcessInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
 		C57AD98920EAA39A0087B24B /* Entitlements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
-		C58159001EA6D02700FC6C3D /* MGLVectorTileSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLVectorTileSource.swift; sourceTree = "<group>"; };
+		C58159001EA6D02700FC6C3D /* MLNVectorTileSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLNVectorTileSource.swift; sourceTree = "<group>"; };
 		C582BA2B2073E77E00647DAA /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		C582FD5E203626E900A9086E /* CLLocationDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationDirection.swift; sourceTree = "<group>"; };
 		C58821FF1FB0F0D7008B0A2D /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -844,8 +844,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C53352A7278DD925003DEC63 /* Mapbox in Frameworks */,
 				C538E4F0278DC97600200823 /* MapboxGeocoder.xcframework in Frameworks */,
+				7170CCBA2B6D2AE00054DF8E /* MapLibre in Frameworks */,
 				C538E4F1278DC97600200823 /* Turf.xcframework in Frameworks */,
 				2CEB743228D078E6007ED4A9 /* Solar.xcframework in Frameworks */,
 			);
@@ -878,7 +878,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C533529B278DD8ED003DEC63 /* Mapbox in Frameworks */,
+				7170CCBC2B6D2AF10054DF8E /* MapLibre in Frameworks */,
 				C538E501278DCD0900200823 /* Solar.xcframework in Frameworks */,
 				35E9B0AD1F9E0F8F00BF84AB /* MapboxNavigation.framework in Frameworks */,
 				C538E4FF278DCD0800200823 /* Polyline.xcframework in Frameworks */,
@@ -928,7 +928,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C53352A3278DD917003DEC63 /* Mapbox in Frameworks */,
+				7170CCBE2B6D2B570054DF8E /* MapLibre in Frameworks */,
 				C538E51D278DCD2A00200823 /* Solar.xcframework in Frameworks */,
 				C53F2EEA20EBC95600D9798F /* MapboxNavigation.framework in Frameworks */,
 				C538E51B278DCD2900200823 /* Polyline.xcframework in Frameworks */,
@@ -1259,11 +1259,11 @@
 				C51511D020EAC89D00372A91 /* CPMapTemplate.swift */,
 				8D24A2F920449B430098CBF8 /* Dictionary.swift */,
 				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
-				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
-				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
-				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
-				353E3C8E20A3501C00FD1789 /* MGLStyle.swift */,
-				C58159001EA6D02700FC6C3D /* MGLVectorTileSource.swift */,
+				351BEBDF1E5BCC63006FE110 /* MLNMapView.swift */,
+				35D825F91E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.h */,
+				35D825FA1E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.m */,
+				353E3C8E20A3501C00FD1789 /* MLNStyle.swift */,
+				C58159001EA6D02700FC6C3D /* MLNVectorTileSource.swift */,
 				8D5DFFF0207C04840093765A /* NSAttributedString.swift */,
 				AE997D2121137B8B00EB0AAB /* String+LocalizedConstants.swift */,
 				35B7837D1F9547B300291F9A /* Transitioning.swift */,
@@ -1453,7 +1453,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA23C9611F4FC05C00BA9522 /* MGLMapView+MGLNavigationAdditions.h in Headers */,
+				DA23C9611F4FC05C00BA9522 /* MLNMapView+MLNNavigationAdditions.h in Headers */,
 				35D825FE1E6A2EC60088F83B /* MapboxNavigation.h in Headers */,
 				DADAD82E20350849002E25CA /* MBRouteVoiceController.h in Headers */,
 			);
@@ -1488,7 +1488,7 @@
 			);
 			name = MapboxNavigation;
 			packageProductDependencies = (
-				C53352A6278DD925003DEC63 /* Mapbox */,
+				7170CCB92B6D2AE00054DF8E /* MapLibre */,
 			);
 			productName = MapboxNavigation;
 			productReference = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */;
@@ -1569,7 +1569,7 @@
 			);
 			name = "Example-Swift";
 			packageProductDependencies = (
-				C533529A278DD8ED003DEC63 /* Mapbox */,
+				7170CCBB2B6D2AF10054DF8E /* MapLibre */,
 			);
 			productName = "Example-Swift";
 			productReference = 358D14631E5E3B7700ADE590 /* Example-Swift.app */;
@@ -1637,7 +1637,7 @@
 			);
 			name = "Example-CarPlay";
 			packageProductDependencies = (
-				C53352A2278DD917003DEC63 /* Mapbox */,
+				7170CCBD2B6D2B570054DF8E /* MapLibre */,
 			);
 			productName = "Example-Swift";
 			productReference = C53F2F0720EBC95600D9798F /* Example-CarPlay.app */;
@@ -1999,9 +1999,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				351BEBF11E5BCC63006FE110 /* MGLMapView.swift in Sources */,
+				351BEBF11E5BCC63006FE110 /* MLNMapView.swift in Sources */,
 				351BEC061E5BCC6C006FE110 /* ManeuverDirection.swift in Sources */,
-				35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */,
+				35D825FC1E6A2DBE0088F83B /* MLNMapView+MLNNavigationAdditions.m in Sources */,
 				C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */,
 				353280A11FA72871005175F3 /* InstructionLabel.swift in Sources */,
 				351BEBFF1E5BCC63006FE110 /* ManeuversStyleKit.swift in Sources */,
@@ -2034,14 +2034,14 @@
 				C5FFAC1520D96F5C009E7F98 /* CarPlayNavigationViewController.swift in Sources */,
 				8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */,
 				8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */,
-				353E3C8F20A3501C00FD1789 /* MGLStyle.swift in Sources */,
+				353E3C8F20A3501C00FD1789 /* MLNStyle.swift in Sources */,
 				35379D0221480E1300FD402E /* CarPlayManager+Search.swift in Sources */,
 				DADAD82F20350849002E25CA /* MBRouteVoiceController.m in Sources */,
 				AE997D2221137B8B00EB0AAB /* String+LocalizedConstants.swift in Sources */,
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,
 				16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */,
 				8D53136B20653FA20044891E /* ExitView.swift in Sources */,
-				C58159011EA6D02700FC6C3D /* MGLVectorTileSource.swift in Sources */,
+				C58159011EA6D02700FC6C3D /* MLNVectorTileSource.swift in Sources */,
 				351BEC011E5BCC63006FE110 /* ManeuverView.swift in Sources */,
 				35B1E2951F1FF8EC00A13D32 /* UserCourseView.swift in Sources */,
 				35B5A47E1FFFDCE5000A3C8D /* NavigationViewLayout.swift in Sources */,
@@ -2703,7 +2703,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 49N5VVHQNN;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2730,7 +2730,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 49N5VVHQNN;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -3258,28 +3258,28 @@
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
 				kind = exactVersion;
-				version = 5.12.2;
+				version = 6.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C533529A278DD8ED003DEC63 /* Mapbox */ = {
+		7170CCB92B6D2AE00054DF8E /* MapLibre */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = Mapbox;
+			productName = MapLibre;
+		};
+		7170CCBB2B6D2AF10054DF8E /* MapLibre */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapLibre;
+		};
+		7170CCBD2B6D2B570054DF8E /* MapLibre */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapLibre;
 		};
 		C533529E278DD90B003DEC63 /* Mapbox */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = Mapbox;
-		};
-		C53352A2278DD917003DEC63 /* Mapbox */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = Mapbox;
-		};
-		C53352A6278DD925003DEC63 /* Mapbox */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5335299278DD8ED003DEC63 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = Mapbox;

--- a/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
       "state" : {
-        "revision" : "d761956e81e74d8bdbfba31e0ec3a75616190658",
-        "version" : "5.12.2"
+        "revision" : "3df876f8f2c6c591b0f66a29b3e216020afc885c",
+        "version" : "6.0.0"
       }
     }
   ],

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -1,9 +1,10 @@
 import Foundation
+import MapLibre
 #if canImport(CarPlay)
 import CarPlay
 
 @available(iOS 12.0, *)
-class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
+class CarPlayMapViewController: UIViewController, MLNMapViewDelegate {
     
     static let defaultAltitude: CLLocationDistance = 16000
     
@@ -83,9 +84,9 @@ class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
     }
 
     
-    // MARK: - MGLMapViewDelegate
+    // MARK: - MLNMapViewDelegate
 
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         if let mapView = mapView as? NavigationMapView {
             mapView.localizeLabels()
         }
@@ -129,7 +130,7 @@ extension CarPlayMapViewController: StyleManagerDelegate {
     func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         let styleURL = style.previewMapStyleURL
         if mapView.styleURL != styleURL {
-            mapView.style?.transition = MGLTransition(duration: 0.5, delay: 0)
+            mapView.style?.transition = MLNTransition(duration: 0.5, delay: 0)
             mapView.styleURL = styleURL
         }
     }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MapLibre
 import MapboxDirections
 import MapboxCoreNavigation
 #if canImport(CarPlay)
@@ -11,7 +12,7 @@ import CarPlay
  */
 @available(iOS 12.0, *)
 @objc(MBCarPlayNavigationViewController)
-public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelegate {
+public class CarPlayNavigationViewController: UIViewController, MLNMapViewDelegate {
     /**
      The view controller’s delegate.
      */
@@ -177,7 +178,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         mapView?.enableFrameByFrameCourseViewTracking(for: 1)
     }
     
-    public func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    public func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         self.mapView?.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         self.mapView?.showRoutes([routeController.routeProgress.route])
         self.mapView?.showWaypoints(routeController.routeProgress.route)
@@ -196,7 +197,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
         
         // Update the user puck
-        let camera = MGLMapCamera(lookingAtCenter: location.coordinate, fromDistance: 120, pitch: 60, heading: location.course)
+        let camera = MLNMapCamera(lookingAtCenter: location.coordinate, fromDistance: 120, pitch: 60, heading: location.course)
         mapView?.updateCourseTracking(location: location, camera: camera, animated: true)
         
         let congestionLevel = routeProgress.averageCongestionLevelRemainingOnLeg ?? .unknown
@@ -348,7 +349,7 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         if mapView?.styleURL != style.mapStyleURL {
-            mapView?.style?.transition = MGLTransition(duration: 0.5, delay: 0)
+            mapView?.style?.transition = MLNTransition(duration: 0.5, delay: 0)
             mapView?.styleURL = style.mapStyleURL
         }
     }

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mapbox
+import MapLibre
 
 
 extension UIColor {
@@ -49,7 +49,7 @@ open class DayStyle: Style {
     
     public required init() {
         super.init()
-        mapStyleURL = MGLStyle.navigationGuidanceDayStyleURL
+        mapStyleURL = MLNStyle.navigationGuidanceDayStyleURL
         styleType = .day
         statusBarStyle = .default
     }
@@ -171,8 +171,8 @@ open class NightStyle: DayStyle {
     
     public required init() {
         super.init()
-        mapStyleURL = MGLStyle.navigationGuidanceNightStyleURL
-        previewMapStyleURL = MGLStyle.navigationPreviewNightStyleURL
+        mapStyleURL = MLNStyle.navigationGuidanceNightStyleURL
+        previewMapStyleURL = MLNStyle.navigationPreviewNightStyleURL
         styleType = .night
         statusBarStyle = .lightContent
     }

--- a/MapboxNavigation/MLNMapView+MLNNavigationAdditions.h
+++ b/MapboxNavigation/MLNMapView+MLNNavigationAdditions.h
@@ -1,6 +1,6 @@
-#import <Mapbox/Mapbox.h>
+#import <MapLibre/Mapbox.h>
 
-@interface MGLMapView (MGLNavigationAdditions)
+@interface MLNMapView (MLNNavigationAdditions)
 
 - (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered;
 

--- a/MapboxNavigation/MLNMapView+MLNNavigationAdditions.m
+++ b/MapboxNavigation/MLNMapView+MLNNavigationAdditions.m
@@ -1,8 +1,8 @@
-#import "MGLMapView+MGLNavigationAdditions.h"
+#import "MLNMapView+MLNNavigationAdditions.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincomplete-implementation"
-@implementation MGLMapView (MGLNavigationAdditions)
+@implementation MLNMapView (MLNNavigationAdditions)
 #pragma clang diagnostic pop
 
 @end

--- a/MapboxNavigation/MLNMapView.swift
+++ b/MapboxNavigation/MLNMapView.swift
@@ -1,12 +1,12 @@
 import Foundation
-import Mapbox
+import MapLibre
 import MapboxDirections
 import MapboxCoreNavigation
 
 /**
- An extension on `MGLMapView` that allows for toggling traffic on a map style that contains a [Mapbox Traffic source](https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/).
+ An extension on `MLNMapView` that allows for toggling traffic on a map style that contains a [Mapbox Traffic source](https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/).
  */
-extension MGLMapView {
+extension MLNMapView {
     /**
      Returns a set of source identifiers for tilesets that are or include the Mapbox Incidents source.
      */
@@ -15,7 +15,7 @@ extension MGLMapView {
             return []
         }
         return Set(style.sources.compactMap {
-            $0 as? MGLVectorTileSource
+            $0 as? MLNVectorTileSource
         }.filter {
             $0.configurationURL?.host?.components(separatedBy: ",").contains(tileSetIdentifier) ?? false
         }.map {
@@ -36,7 +36,7 @@ extension MGLMapView {
         
         let incidentsSourceIdentifiers = sourceIdentifiers(forTileSetIdentifier: tileSetIdentifier)
         for layer in style.layers {
-            if let layer = layer as? MGLVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
+            if let layer = layer as? MLNVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
                 if incidentsSourceIdentifiers.contains(sourceIdentifier) && layer.sourceLayerIdentifier == layerIdentifier {
                     return layer.isVisible
                 }
@@ -58,7 +58,7 @@ extension MGLMapView {
         
         let incidentsSourceIdentifiers = sourceIdentifiers(forTileSetIdentifier: tileSetIdentifier)
         for layer in style.layers {
-            if let layer = layer as? MGLVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
+            if let layer = layer as? MLNVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
                 if incidentsSourceIdentifiers.contains(sourceIdentifier) && layer.sourceLayerIdentifier == layerIdentifier {
                     layer.isVisible = isVisible
                 }

--- a/MapboxNavigation/MLNStyle.swift
+++ b/MapboxNavigation/MLNStyle.swift
@@ -1,8 +1,8 @@
 import Foundation
-import Mapbox
+import MapLibre
 
 
-extension MGLStyle {
+extension MLNStyle {
     
     // The Mapbox China Day Style URL.
     static let mapboxChinaDayStyleURL = URL(string:"mapbox://styles/mapbox/streets-zh-v1")!

--- a/MapboxNavigation/MLNVectorTileSource.swift
+++ b/MapboxNavigation/MLNVectorTileSource.swift
@@ -1,7 +1,7 @@
 import Foundation
-import Mapbox
+import MapLibre
 
-extension MGLVectorTileSource {
+extension MLNVectorTileSource {
     var isMapboxStreets: Bool {
         guard let configurationURL = configurationURL else {
             return false

--- a/MapboxNavigation/MapboxNavigation.h
+++ b/MapboxNavigation/MapboxNavigation.h
@@ -7,4 +7,4 @@ FOUNDATION_EXPORT double MapboxNavigationVersionNumber;
 FOUNDATION_EXPORT const unsigned char MapboxNavigationVersionString[];
 
 #import "MBRouteVoiceController.h"
-#import "MGLMapView+MGLNavigationAdditions.h"
+#import "MLNMapView+MLNNavigationAdditions.h"

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -231,6 +231,6 @@ open class NavigationView: UIView {
     }
 }
 
-protocol NavigationViewDelegate: NavigationMapViewDelegate, MGLMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
+protocol NavigationViewDelegate: NavigationMapViewDelegate, MLNMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import MapboxCoreNavigation
 import MapboxDirections
-import Mapbox
+import MapLibre
 #if canImport(CarPlay)
 import CarPlay
 #endif
@@ -78,56 +78,56 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     optional func navigationViewController(_ navigationViewController: NavigationViewController, didFailToRerouteWith error: Error)
     
     /**
-     Returns an `MGLStyleLayer` that determines the appearance of the route line.
+     Returns an `MLNStyleLayer` that determines the appearance of the route line.
      
-     If this method is unimplemented, the navigation view controller’s map view draws the route line using an `MGLLineStyleLayer`.
+     If this method is unimplemented, the navigation view controller’s map view draws the route line using an `MLNLineStyleLayer`.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer?
     
     /**
-     Returns an `MGLStyleLayer` that determines the appearance of the route line’s casing.
+     Returns an `MLNStyleLayer` that determines the appearance of the route line’s casing.
      
-     If this method is unimplemented, the navigation view controller’s map view draws the route line’s casing using an `MGLLineStyleLayer` whose width is greater than that of the style layer returned by `navigationViewController(_:routeStyleLayerWithIdentifier:source:)`.
+     If this method is unimplemented, the navigation view controller’s map view draws the route line’s casing using an `MLNLineStyleLayer` whose width is greater than that of the style layer returned by `navigationViewController(_:routeStyleLayerWithIdentifier:source:)`.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer?
     
     /**
-     Returns an `MGLShape` that represents the path of the route line.
+     Returns an `MLNShape` that represents the path of the route line.
      
-     If this method is unimplemented, the navigation view controller’s map view represents the route line using an `MGLPolylineFeature` based on `route`’s `coordinates` property.
+     If this method is unimplemented, the navigation view controller’s map view represents the route line using an `MLNPolylineFeature` based on `route`’s `coordinates` property.
      */
     @objc(navigationViewController:shapeForRoutes:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor routes: [Route]) -> MGLShape?
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor routes: [Route]) -> MLNShape?
     
     /**
-     Returns an `MGLShape` that represents the path of the route line’s casing.
+     Returns an `MLNShape` that represents the path of the route line’s casing.
      
-     If this method is unimplemented, the navigation view controller’s map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationViewController(_:shapeFor:)`.
+     If this method is unimplemented, the navigation view controller’s map view represents the route line’s casing using an `MLNPolylineFeature` identical to the one returned by `navigationViewController(_:shapeFor:)`.
      */
     @objc(navigationViewController:simplifiedShapeForRoute:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, simplifiedShapeFor route: Route) -> MGLShape?
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, simplifiedShapeFor route: Route) -> MLNShape?
     
     /*
-     Returns an `MGLStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
+     Returns an `MLNStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
      
      If this method is unimplemented, the navigation view controller’s map view marks each destination waypoint with a circle.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer?
     
     /*
-     Returns an `MGLStyleLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`.
+     Returns an `MLNStyleLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`.
      
      If this method is unimplemented, the navigation view controller’s map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer?
     
     /**
-     Returns an `MGLShape` that represents the destination waypoints along the route (that is, excluding the origin).
+     Returns an `MLNShape` that represents the destination waypoints along the route (that is, excluding the origin).
      
      If this method is unimplemented, the navigation map view represents the route waypoints using `navigationViewController(_:shapeFor:legIndex:)`.
      */
     @objc(navigationViewController:shapeForWaypoints:legIndex:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> MLNShape?
     
     /**
      Called when the user taps to select a route on the navigation view controller’s map view.
@@ -138,20 +138,20 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     optional func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route)
     
     /**
-     Return an `MGLAnnotationImage` that represents the destination marker.
+     Return an `MLNAnnotationImage` that represents the destination marker.
      
      If this method is unimplemented, the navigation view controller’s map view will represent the destination annotation with the default marker.
      */
     @objc(navigationViewController:imageForAnnotation:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MLNAnnotation) -> MLNAnnotationImage?
     
     /**
      Returns a view object to mark the given point annotation object on the map.
      
-     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation`, return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof). Note that when `NavigationMapView.tracksUserCourse` is set to `true`, the navigation view controller’s map view uses a distinct user course view; to customize it, set the `NavigationMapView.userCourseView` property of the map view stored by the `NavigationViewController.mapView` property.
+     The user location annotation view can also be customized via this method. When annotation is an instance of `MLNUserLocation`, return an instance of `MLNUserLocationAnnotationView` (or a subclass thereof). Note that when `NavigationMapView.tracksUserCourse` is set to `true`, the navigation view controller’s map view uses a distinct user course view; to customize it, set the `NavigationMapView.userCourseView` property of the map view stored by the `NavigationViewController.mapView` property.
      */
     @objc(navigationViewController:viewForAnnotation:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, viewFor annotation: MLNAnnotation) -> MLNAnnotationView?
     
     /**
      Returns the center point of the user course view in screen coordinates relative to the map view.
@@ -217,14 +217,14 @@ open class NavigationViewController: UIViewController {
     @objc public var directions: Directions!
     
     /**
-     An optional `MGLMapCamera` you can use to improve the initial transition from a previous viewport and prevent a trigger from an excessive significant location update.
+     An optional `MLNMapCamera` you can use to improve the initial transition from a previous viewport and prevent a trigger from an excessive significant location update.
      */
-    @objc public var pendingCamera: MGLMapCamera?
+    @objc public var pendingCamera: MLNMapCamera?
     
     /**
-     An instance of `MGLAnnotation` representing the origin of your route.
+     An instance of `MLNAnnotation` representing the origin of your route.
      */
-    @objc public var origin: MGLAnnotation?
+    @objc public var origin: MLNAnnotation?
     
     /**
      The receiver’s delegate.
@@ -547,11 +547,11 @@ open class NavigationViewController: UIViewController {
 
 //MARK: - RouteMapViewControllerDelegate
 extension NavigationViewController: RouteMapViewControllerDelegate {
-    public func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    public func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationViewController?(self, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    public func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    public func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationViewController?(self, routeStyleLayerWithIdentifier: identifier, source: source)
     }
     
@@ -559,31 +559,31 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         delegate?.navigationViewController?(self, didSelect: route)
     }
     
-    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MGLShape? {
+    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MLNShape? {
         return delegate?.navigationViewController?(self, shapeFor: routes)
     }
     
-    @objc public func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
+    @objc public func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MLNShape? {
         return delegate?.navigationViewController?(self, simplifiedShapeFor: route)
     }
     
-    public func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    public func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationViewController?(self, waypointStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    public func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    public func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationViewController?(self, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
+    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MLNShape? {
         return delegate?.navigationViewController?(self, shapeFor: waypoints, legIndex: legIndex)
     }
     
-    @objc public func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+    @objc public func navigationMapView(_ mapView: MLNMapView, imageFor annotation: MLNAnnotation) -> MLNAnnotationImage? {
         return delegate?.navigationViewController?(self, imageFor: annotation)
     }
     
-    @objc public func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+    @objc public func navigationMapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
         return delegate?.navigationViewController?(self, viewFor: annotation)
     }
     
@@ -694,7 +694,7 @@ extension NavigationViewController: StyleManagerDelegate {
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         if mapView?.styleURL != style.mapStyleURL {
-            mapView?.style?.transition = MGLTransition(duration: 0.5, delay: 0)
+            mapView?.style?.transition = MLNTransition(duration: 0.5, delay: 0)
             mapView?.styleURL = style.mapStyleURL
         }
         

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -1,11 +1,11 @@
 import UIKit
-import Mapbox
+import MapLibre
 import MapboxDirections
 import MapboxCoreNavigation
 import Turf
 import AVFoundation
 
-class ArrowFillPolyline: MGLPolylineFeature {}
+class ArrowFillPolyline: MLNPolylineFeature {}
 class ArrowStrokePolyline: ArrowFillPolyline {}
 
 class RouteMapViewController: UIViewController {
@@ -50,14 +50,14 @@ class RouteMapViewController: UIViewController {
 
     var showsEndOfRoute: Bool = true
 
-    var pendingCamera: MGLMapCamera? {
+    var pendingCamera: MLNMapCamera? {
         guard let parent = parent as? NavigationViewController else {
             return nil
         }
         return parent.pendingCamera
     }
 
-    var tiltedCamera: MGLMapCamera {
+    var tiltedCamera: MLNMapCamera {
         get {
             let camera = mapView.camera
             camera.altitude = 1000
@@ -373,11 +373,11 @@ class RouteMapViewController: UIViewController {
         mapView.altitude = altitude
     }
 
-    func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+    func mapView(_ mapView: MLNMapView, imageFor annotation: MLNAnnotation) -> MLNAnnotationImage? {
         return navigationMapView(mapView, imageFor: annotation)
     }
 
-    func mapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+    func mapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
         return navigationMapView(mapView, viewFor: annotation)
     }
 
@@ -462,7 +462,7 @@ class RouteMapViewController: UIViewController {
 
         if let coordinates = routeController.routeProgress.route.coordinates, let userLocation = routeController?.locationManager.location?.coordinate {
             let slicedLine = Polyline(coordinates).sliced(from: userLocation).coordinates
-            let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
+            let line = MLNPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
 
             let camera = navigationView.mapView.cameraThatFitsShape(line, direction: navigationView.mapView.camera.heading, edgePadding: insets)
             camera.pitch = 0
@@ -528,8 +528,8 @@ extension RouteMapViewController: NavigationViewDelegate {
         delegate?.mapViewControllerDidDismiss(self, byCanceling: true)
     }
 
-    // MARK: MGLMapViewDelegate
-    func mapView(_ mapView: MGLMapView, regionDidChangeAnimated animated: Bool) {
+    // MARK: MLNMapViewDelegate
+    func mapView(_ mapView: MLNMapView, regionDidChangeAnimated animated: Bool) {
         var userTrackingMode = mapView.userTrackingMode
         if let mapView = mapView as? NavigationMapView, mapView.tracksUserCourse {
             userTrackingMode = .followWithCourse
@@ -539,7 +539,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         }
     }
 
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         // This method is called before the view is added to a window
         // (if the style is cached) preventing UIAppearance to apply the style.
         showRouteIfNeeded()
@@ -547,7 +547,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         delegate?.mapView?(mapView, didFinishLoading: style)
     }
 
-    func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
+    func mapViewDidFinishLoadingMap(_ mapView: MLNMapView) {
         delegate?.mapViewDidFinishLoadingMap?(mapView)
     }
 
@@ -602,27 +602,27 @@ extension RouteMapViewController: NavigationViewDelegate {
     }
 
     //MARK: NavigationMapViewDelegate
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationMapView?(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationMapView?(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationMapView?(mapView, waypointStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MLNSource) -> MLNStyleLayer? {
         return delegate?.navigationMapView?(mapView, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
+    func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MLNShape? {
         return delegate?.navigationMapView?(mapView, shapeFor: waypoints, legIndex: legIndex)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MGLShape? {
+    func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MLNShape? {
         return delegate?.navigationMapView?(mapView, shapeFor: routes)
     }
 
@@ -630,15 +630,15 @@ extension RouteMapViewController: NavigationViewDelegate {
         delegate?.navigationMapView?(mapView, didSelect: route)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MLNShape? {
         return delegate?.navigationMapView?(mapView, simplifiedShapeFor: route)
     }
 
-    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+    func navigationMapView(_ mapView: MLNMapView, imageFor annotation: MLNAnnotation) -> MLNAnnotationImage? {
         return delegate?.navigationMapView?(mapView, imageFor: annotation)
     }
 
-    func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+    func navigationMapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
         return delegate?.navigationMapView?(mapView, viewFor: annotation)
     }
 
@@ -688,21 +688,21 @@ extension RouteMapViewController: NavigationViewDelegate {
 
         let closestCoordinate = location.coordinate
         let roadLabelLayerIdentifier = "roadLabelLayer"
-        var streetsSources: [MGLVectorTileSource] = style.sources.compactMap {
-            $0 as? MGLVectorTileSource
+        var streetsSources: [MLNVectorTileSource] = style.sources.compactMap {
+            $0 as? MLNVectorTileSource
             }.filter {
                 $0.isMapboxStreets
         }
 
         // Add Mapbox Streets if the map does not already have it
         if streetsSources.isEmpty {
-            let source = MGLVectorTileSource(identifier: "mapboxStreetsv7", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v7")!)
+            let source = MLNVectorTileSource(identifier: "mapboxStreetsv7", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v7")!)
             style.addSource(source)
             streetsSources.append(source)
         }
 
         if let mapboxSteetsSource = streetsSources.first, style.layer(withIdentifier: roadLabelLayerIdentifier) == nil {
-            let streetLabelLayer = MGLLineStyleLayer(identifier: roadLabelLayerIdentifier, source: mapboxSteetsSource)
+            let streetLabelLayer = MLNLineStyleLayer(identifier: roadLabelLayerIdentifier, source: mapboxSteetsSource)
             streetLabelLayer.sourceLayerIdentifier = "road_label"
             streetLabelLayer.lineOpacity = NSExpression(forConstantValue: 1)
             streetLabelLayer.lineWidth = NSExpression(forConstantValue: 20)
@@ -717,11 +717,11 @@ extension RouteMapViewController: NavigationViewDelegate {
         var currentShieldName: NSAttributedString?
 
         for feature in features {
-            var allLines: [MGLPolyline] = []
+            var allLines: [MLNPolyline] = []
 
-            if let line = feature as? MGLPolylineFeature {
+            if let line = feature as? MLNPolylineFeature {
                 allLines.append(line)
-            } else if let lines = feature as? MGLMultiPolylineFeature {
+            } else if let lines = feature as? MLNMultiPolylineFeature {
                 allLines = lines.polylines
             }
 
@@ -742,11 +742,11 @@ extension RouteMapViewController: NavigationViewDelegate {
                 if minDistanceBetweenPoints < smallestLabelDistance {
                     smallestLabelDistance = minDistanceBetweenPoints
 
-                    if let line = feature as? MGLPolylineFeature {
+                    if let line = feature as? MLNPolylineFeature {
                         let roadNameRecord = roadFeature(for: line)
                         currentShieldName = roadNameRecord.shieldName
                         currentName = roadNameRecord.roadName
-                    } else if let line = feature as? MGLMultiPolylineFeature {
+                    } else if let line = feature as? MLNMultiPolylineFeature {
                         let roadNameRecord = roadFeature(for: line)
                         currentShieldName = roadNameRecord.shieldName
                         currentName = roadNameRecord.roadName
@@ -768,7 +768,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         }
     }
 
-    private func roadFeature(for line: MGLPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
+    private func roadFeature(for line: MLNPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
         let roadNameRecord = roadFeatureHelper(ref: line.attribute(forKey: "ref"),
                                             shield: line.attribute(forKey: "shield"),
                                             reflen: line.attribute(forKey: "reflen"),
@@ -777,7 +777,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         return (roadName: roadNameRecord.roadName, shieldName: roadNameRecord.shieldName)
     }
 
-    private func roadFeature(for line: MGLMultiPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
+    private func roadFeature(for line: MLNMultiPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
         let roadNameRecord = roadFeatureHelper(ref: line.attribute(forKey: "ref"),
                                             shield: line.attribute(forKey: "shield"),
                                             reflen: line.attribute(forKey: "reflen"),
@@ -967,7 +967,7 @@ fileprivate extension UIView.AnimationOptions {
         }
     }
 }
-@objc protocol RouteMapViewControllerDelegate: NavigationMapViewDelegate, MGLMapViewDelegate, VisualInstructionDelegate {
+@objc protocol RouteMapViewControllerDelegate: NavigationMapViewDelegate, MLNMapViewDelegate, VisualInstructionDelegate {
     func mapViewControllerDidDismiss(_ mapViewController: RouteMapViewController, byCanceling canceled: Bool)
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
 

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -34,20 +34,20 @@ open class Style: NSObject {
     /**
      URL of the style to display on the map during turn-by-turn navigation.
      */
-    @objc open var mapStyleURL: URL = MGLStyle.navigationGuidanceDayStyleURL
+    @objc open var mapStyleURL: URL = MLNStyle.navigationGuidanceDayStyleURL
     
     #if canImport(CarPlay)
     /**
      URL of the style to display on the map when previewing a route, for example on CarPlay.
      */
-    @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
+    @objc open var previewMapStyleURL = MLNStyle.navigationPreviewDayStyleURL
     #else
     /**
      URL of the style to display on the map when previewing a route.
      
      This property is currently unused by default, but you can use it to present your own route preview map.
      */
-    @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
+    @objc open var previewMapStyleURL = MLNStyle.navigationPreviewDayStyleURL
     #endif
     
     /**

--- a/MapboxNavigation/UserCourseView.swift
+++ b/MapboxNavigation/UserCourseView.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Turf
-import Mapbox
+import MapLibre
 
 let PuckSize: CGFloat = 45
 let ArrowSize = PuckSize * 0.6

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -204,9 +204,9 @@ class NavigationViewControllerTests: XCTestCase {
         
     }
     
-    private func annotationFilter(matching coordinate: CLLocationCoordinate2D) -> ((MGLAnnotation) -> Bool) {
-        let filter = { (annotation: MGLAnnotation) -> Bool in
-            guard let pointAnno = annotation as? MGLPointAnnotation else { return false }
+    private func annotationFilter(matching coordinate: CLLocationCoordinate2D) -> ((MLNAnnotation) -> Bool) {
+        let filter = { (annotation: MLNAnnotation) -> Bool in
+            guard let pointAnno = annotation as? MLNPointAnnotation else { return false }
             return pointAnno.coordinate == coordinate
         }
         return filter
@@ -267,7 +267,7 @@ class NavigationViewControllerTestable: NavigationViewController {
         fatalError("init(for:directions:styles:routeController:locationManager:voiceController:) is not supported in this testing subclass.")
     }
 
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         styleLoadedExpectation.fulfill()
     }
     

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All issues are covered with this SDK.
 # What have we changed
 
 - Removed EventManager and all its references, this manager collected telemetry data which we don't want to send
-- Transitioned from the [Mapbox SDK](https://github.com/mapbox/mapbox-gl-native-ios) (version 4.3) to [Maplibre Maps SDK](https://github.com/maplibre/maplibre-gl-native) (version 5.12.2)
+- Transitioned from the [Mapbox SDK](https://github.com/mapbox/mapbox-gl-native-ios) (version 4.3) to [Maplibre Maps SDK](https://github.com/maplibre/maplibre-gl-native) (version 6.0.0)
 - Added optional config parameter in NavigationMapView constructor to customize certain properties like route line color
 
 # Getting Started
@@ -33,7 +33,7 @@ If you are looking to include this inside your project, you have to follow the t
    - Change location to root of XCode project: `cd path/to/Project`
     - Create the Cartfile: `touch Cartfile`
    - New file will be added: `Cartfile`
-1. Add Maplibre Maps SPM (Swift Package Manager) depedency by going to your app's project file -> Package Dependencies -> Press the '+' -> https://github.com/maplibre/maplibre-gl-native-distribution -> 'Exact' 5.12.2 
+1. Add Maplibre Maps SPM (Swift Package Manager) depedency by going to your app's project file -> Package Dependencies -> Press the '+' -> https://github.com/maplibre/maplibre-gl-native-distribution -> 'Exact' 6.0.0 
 1. Add dependencies to Cartfile
    ```
    github "maplibre/maplibre-navigation-ios" ~> 2.0.0
@@ -68,7 +68,7 @@ In order to see the map or calculate a route you need your own Maptile and Direc
 Use the following code as inspiration:
 
 ```
-import Mapbox
+import MapLibre
 import MapboxDirections
 import MapboxCoreNavigation
 import MapboxNavigation
@@ -136,7 +136,7 @@ class ViewController: UIViewController {
 
 extension ViewController: RouteControllerDelegate {
     @objc public func routeController(_ routeController: RouteController, didUpdate locations: [CLLocation]) {
-        let camera = MGLMapCamera(
+        let camera = MLNMapCamera(
             lookingAtCenter: locations.first!.coordinate,
             acrossDistance: 500,
             pitch: 0,


### PR DESCRIPTION
updated MapLibre Native dependency to use the ios-v6.0.0 version (https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.0.0).
Full refactoring to MapLibre / MLN naming convention still to be done.
Please test and review in-depth, as most of the refactoring was made on a find&replace base.