### PR TITLE
Configure first voice instruction.

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -64,6 +64,11 @@ open class RouteController: NSObject, Router {
      */
     public var tunnelIntersectionManager: TunnelIntersectionManager = TunnelIntersectionManager()
 
+    /**
+     If true, the first voice announcement is always triggered when beginning a leg.
+     */
+    public var speakFirstInstructionOnFirstStep = true
+
     var didFindFasterRoute = false
 
     /**
@@ -779,8 +784,10 @@ extension RouteController: CLLocationManagerDelegate {
         guard let userSnapToStepDistanceFromManeuver = userSnapToStepDistanceFromManeuver else { return }
         guard let spokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
 
+        let firstInstructionOnFirstStep = speakFirstInstructionOnFirstStep
         // Always give the first voice announcement when beginning a leg.
-        let firstInstructionOnFirstStep = routeProgress.currentLegProgress.stepIndex == 0 && routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex == 0
+        ? routeProgress.currentLegProgress.stepIndex == 0 && routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex == 0
+        : false
 
         for voiceInstruction in spokenInstructions {
             if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep || firstInstructionOnFirstStep {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -177,7 +177,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     @objc open func didPassSpokenInstructionPoint(notification: NSNotification) {
         guard !NavigationSettings.shared.voiceMuted else { return }
         
-        routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+        routeProgress = notification.userInfo?[RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
         assert(routeProgress != nil, "routeProgress should not be nil.")
 
         guard let instruction = routeProgress?.currentLegProgress.currentStepProgress.currentSpokenInstruction else { return }
@@ -194,7 +194,10 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
      - parameter locale: The `Locale` used to create the voice read aloud the given instruction. If `nil` the `Locale.preferredLocalLanguageCountryCode` is used for creating the voice.
      */
     open func speak(_ instruction: SpokenInstruction, with locale: Locale?) {
-        assert(routeProgress != nil, "routeProgress should not be nil.")
+        guard let routeProgress else {
+            assertionFailure("routeProgress should not be nil.")
+            return
+        }
         
         if speechSynth.isSpeaking, let lastSpokenInstruction = lastSpokenInstruction {
             voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction)
@@ -213,10 +216,10 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
             utterance!.voice = AVSpeechSynthesisVoice(identifier: AVSpeechSynthesisVoiceIdentifierAlex)
         }
         
-        let modifiedInstruction = voiceControllerDelegate?.voiceController?(self, willSpeak: instruction, routeProgress: routeProgress!) ?? instruction
+        let modifiedInstruction = voiceControllerDelegate?.voiceController?(self, willSpeak: instruction, routeProgress: routeProgress) ?? instruction
         
         if #available(iOS 10.0, *), utterance?.voice == nil {
-            utterance = AVSpeechUtterance(attributedString: modifiedInstruction.attributedText(for: routeProgress!.currentLegProgress))
+            utterance = AVSpeechUtterance(attributedString: modifiedInstruction.attributedText(for: routeProgress.currentLegProgress))
         } else {
             utterance = AVSpeechUtterance(string: modifiedInstruction.text)
         }


### PR DESCRIPTION
With the new parameter `speakFirstInstructionOnFirstStep` in `RouteController` the first instruction on the first step can be omitted.