### PR TITLE
Fix failing test for 24 hr locales

### DIFF
--- a/MapboxNavigationTests/Sources/Tests/StyleManagerTests.swift
+++ b/MapboxNavigationTests/Sources/Tests/StyleManagerTests.swift
@@ -80,7 +80,8 @@ class StyleManagerTests: XCTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "hh:mm a"
         dateFormatter.timeZone = TimeZone(identifier: "PST")
-        
+        dateFormatter.locale = Locale(identifier: "en_US")
+
         NSTimeZone.default = NSTimeZone(abbreviation: "PST")! as TimeZone
         
         let beforeSunrise = dateFormatter.date(from: "05:00 AM")!


### PR DESCRIPTION
### Description

This test was failing for me. I use `en-US` locale, but I set my clock to 24 hour. It's admittedly uncommon, but I'd wager this test is failing for anyone in a non-12 hours locale.

```
 let beforeSunrise = dateFormatter.date(from: "05:00 AM")! // Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

To be honest, I expected the existing date format string `hh:mm a` to be sufficient, but apparently it's not.