### PR TITLE
Fix NavigationViewController rerouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
    - Added `Day/NightStyle(demoStyle: ())` as an explicit alternative when the user doesn't have a tileserver handy. This uses MapLibre's demo style and is intended for testing and demonstration use only.
    - Deprecated `DayStyle()`/`NightStyle()` initializers because they were backed by an implicit tile service. If these default styles *are* still used, they'll now use the MapLibre demo style.
    - `NavigationViewController` now expects explicit style URLs with `NavigationViewController(route:dayStyleURL:nightStyleURL:...)` or NavigationViewController(route:dayStyle:nightStyle:...)` and the existing initializer, which allowed "default" styles, is deprecated and uses the MapLibre demo styles.
+ - Fix: NavigationViewController was not re-routing when the user went off route.
+   - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/47>.
 
 ## v2.0.0 (May 23, 2023)
  - Upgrade minimum iOS version from 11.0 to 12.0.

--- a/MapboxCoreNavigation/RouteControllerDelegate.swift
+++ b/MapboxCoreNavigation/RouteControllerDelegate.swift
@@ -22,8 +22,8 @@ public protocol RouteControllerDelegate: AnyObject {
     /**
      Called immediately before the route controller calculates a new route.
      
-     This method is called after `routeController(_:shouldRerouteFrom:)` is called, simultaneously with the `RouteControllerWillReroute` notification being posted, and before `routeController(_:didRerouteAlong:)` is called.
-     
+     This method is called after `routeController(_:shouldRerouteFrom:)` is called, simultaneously with the `RouteControllerWillReroute` notification being posted, and before `routeController(_:didRerouteAlong:reason:)` is called.
+
      - parameter routeController: The route controller that will calculate a new route.
      - parameter location: The user’s current location.
      */

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -35,16 +35,9 @@ private class SimulatedLocation: CLLocation {
     /// ```
     /// extension MyDelegate: SimulatedLocationManagerDelegate {
     ///     func simulatedLocationManager(_ simulatedLocationManager: SimulatedLocationManager, locationFor originalLocation: CLLocation) -> CLLocation {
-    ///         // go off track by 10 meters east
-    ///         let offsetByMeters = 10
-    ///         let bearing = 90
-    ///
-    ///         let distRadians = meters / 6_372_797.6 // earth radius in meters
-    ///         let lat1 = location.coordinate.latitude * .pi / 180
-    ///         let lon1 = location.coordinate.longitude * .pi / 180
-    ///         let lat2 = asin(sin(lat1) * cos(distRadians) + cos(lat1) * sin(distRadians) * cos(bearing))
-    ///         let lon2 = lon1 + atan2(sin(bearing) * sin(distRadians) * cos(lat1), cos(distRadians) - sin(lat1) * sin(lat2))
-    ///         return CLLocation(latitude: lat2 * 180 / .pi, longitude: lon2 * 180 / .pi)
+    ///         // go off track 100 meters East of the original route
+    ///         let offsetCoordinate = originalLocation.coordinate.coordinate(at: 100, facing: 90)
+    ///         return CLLocation(latitude: offsetCoordinate.latitude, longitude: offsetCoordinate.longitude)
     ///     }
     /// }
     /// ```

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -310,7 +310,7 @@ class RouteControllerTests: XCTestCase {
         XCTAssertTrue(self.delegate.recentMessages.contains("routeController(_:shouldPreventReroutesWhenArrivingAt:)"))
         
         // We should not reroute here because the user has arrived.
-        XCTAssertFalse(self.delegate.recentMessages.contains("routeController(_:didRerouteAlong:)"))
+        XCTAssertFalse(self.delegate.recentMessages.contains("routeController(_:didRerouteAlong:reason:)"))
     }
 
     func testRouteControllerDoesNotHaveRetainCycle() {

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -313,6 +313,22 @@ class RouteControllerTests: XCTestCase {
         XCTAssertFalse(self.delegate.recentMessages.contains("routeController(_:didRerouteAlong:reason:)"))
     }
 
+    func testReroutesWhenOffCourse() {
+        let routeController = self.dependencies.routeController
+        let firstLocation = self.dependencies.routeLocations.firstLocation
+
+        // Start the route
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [firstLocation])
+
+        // Go very far off route
+        let locationBeyondRoute = routeController.location!.coordinate.coordinate(at: 2000, facing: 0)
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [CLLocation(latitude: locationBeyondRoute.latitude, longitude: locationBeyondRoute.latitude)])
+
+        // We should reroute because the user was off course.
+        self.directionsClientSpy.fireLastCalculateCompletion(with: nil, routes: [self.alternateRoute], error: nil)
+        XCTAssertTrue(self.delegate.recentMessages.contains("routeController(_:didRerouteAlong:reason:)"))
+    }
+
     func testRouteControllerDoesNotHaveRetainCycle() {
         weak var subject: RouteController? = nil
         

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -695,7 +695,7 @@ extension NavigationViewController: RouteControllerDelegate {
         self.delegate?.navigationViewController?(self, willRerouteFrom: location)
     }
     
-    @objc public func routeController(_ routeController: RouteController, didRerouteAlong route: Route) {
+    @objc public func routeController(_ routeController: RouteController, didRerouteAlong route: Route, reason: RouteController.RerouteReason) {
         self.mapViewController?.notifyDidReroute(route: route)
         self.delegate?.navigationViewController?(self, didRerouteAlong: route)
     }


### PR DESCRIPTION
(**edit:** Sorry for the initial description. I had a CLI misfire.)

~~This is a draft because: ~~
- [x] This is based on #45, so please merge that first.
- [x] Looking for advice on testing the generated objc headers. - From what I can tell, objc build is not currently supported anyway.

The `reason` parameter was added in https://github.com/maplibre/maplibre-navigation-ios/commit/c65c9c64c7acd371e73fb7914f95657832aa42fa#diff-9644714366824e368806302bce45047e92c0c6db14650897cdb254146f8df15cL56, but it was not added to existing callers.

Since it's an `optional` delegate method, no compiler error was triggered, the old method just sat around not being run.