### PR TITLE
Fix simulated speed label in NavigationViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
    - Deprecated `DayStyle()`/`NightStyle()` initializers because they were backed by an implicit tile service. If these default styles *are* still used, they'll now use the MapLibre demo style.
    - `NavigationViewController` now expects explicit style URLs with `NavigationViewController(route:dayStyleURL:nightStyleURL:...)` or NavigationViewController(route:dayStyle:nightStyle:...)` and the existing initializer, which allowed "default" styles, is deprecated and uses the MapLibre demo styles.
  - Fix: NavigationViewController was not re-routing when the user went off route.
-   - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/47>.
+   - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/47>
+ - Fix: NavigationViewController displayed incorrect `speedMultiplier` when using SimulatedLocationManager
+   - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/49>
 
 ## v2.0.0 (May 23, 2023)
  - Upgrade minimum iOS version from 11.0 to 12.0.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -491,8 +491,8 @@ open class NavigationViewController: UIViewController {
             UIApplication.shared.isIdleTimerDisabled = true
         }
         
-        if self.routeController.locationManager is SimulatedLocationManager {
-            let localized = String.Localized.simulationStatus(speed: 1)
+        if let simulatedLocationManager = self.routeController.locationManager as? SimulatedLocationManager {
+            let localized = String.Localized.simulationStatus(speed: Int(simulatedLocationManager.speedMultiplier))
             self.mapViewController?.statusView.show(localized, showSpinner: false, interactive: true)
         }
     }


### PR DESCRIPTION
### Description

For testing purposes, there is a `SimulatedLocationManager`. You give it a route and it updates your "current location" to be along that route. 

To speed up the testing cycle, you can set a speed multiplier on the `SimulatedLocationManager` so that the route is travelled much faster than what it would be in realtime.

When using the `SimulatedLocationManager` the navigation view controller shows what the speed multiplier is. However, it used to always say "Simulating Navigation at 1x" regardless of what you'd set the speed multiplier to.

**before**
<img width="300" alt="Screenshot 2024-05-31 at 10 44 26" src="https://github.com/maplibre/maplibre-navigation-ios/assets/217057/d991f4f7-2db4-4481-bfb1-90258bb57df7">

Now it properly reflects the specified speed
**after**
<img width="300" alt="Screenshot 2024-05-31 at 10 44 02" src="https://github.com/maplibre/maplibre-navigation-ios/assets/217057/9dc821ea-6fcf-4491-9c1a-a5e4af3d68de">

