### PR TITLE
Fix #27: navigation puck falls off route when panning

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -257,9 +257,9 @@ open class NavigationMapView: MLNMapView, UIGestureRecognizerDelegate {
             super.anchorPoint(forGesture: gesture)
         }
     }
-    
-    override open func mapViewDidFinishRenderingFrameFullyRendered(_ fullyRendered: Bool) {
-        super.mapViewDidFinishRenderingFrameFullyRendered(fullyRendered)
+   
+    override open func mapViewDidFinishRenderingFrameFullyRendered(_ fullyRendered: Bool, frameEncodingTime: Double, frameRenderingTime: Double) {
+        super.mapViewDidFinishRenderingFrameFullyRendered(fullyRendered, frameEncodingTime: frameEncodingTime, frameRenderingTime: frameRenderingTime)
         
         guard self.shouldPositionCourseViewFrameByFrame else { return }
         guard let location = userLocationForCourseTracking else { return }

--- a/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.h
+++ b/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.h
@@ -2,6 +2,8 @@
 
 @interface MLNMapView (MLNNavigationAdditions)
 
-- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered;
+- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered
+                                  frameEncodingTime:(double)frameEncodingTime
+                                 frameRenderingTime:(double)frameRenderingTime;
 
 @end


### PR DESCRIPTION
### Description

The bug was especially noticeable when panning quickly or zooming in
while navigating.

The issue is that the upstream method signature changed in
https://github.com/maplibre/maplibre-native/commit/76469a0c2227927f03a15fb95b3a20f34becc78c and then again in
https://github.com/maplibre/maplibre-native/commit/8ad5f9c1fd58c60b93d26c2819637fd8f2144fd1

So our "overridden method" wasn't actually being called.

It's not the commit authors fault that it broke - this is a private
method we're calling.

A longer term fix might be to include some kind of public stable
delegate method rather than an override.

## Before

https://github.com/maplibre/maplibre-navigation-ios/assets/217057/6240dec0-7e48-41b4-be0b-2e3b281257cf

## After

https://github.com/maplibre/maplibre-navigation-ios/assets/217057/9e6bcf5e-e25a-4fca-a241-1932bbf98f77

### Open Tasks

- Fixes #27

### Infos for Reviewer

