### PR TITLE
Make sure the puck stays on the route while animating the map

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -317,14 +317,17 @@ open class NavigationMapView: MLNMapView, UIGestureRecognizerDelegate {
         }
     }
     
-    // Track position on a frame by frame basis. Used for first location update and when resuming tracking mode
-    func enableFrameByFrameCourseViewTracking(for duration: TimeInterval) {
+    // MARK: - User Tracking
+    
+    /**
+     Track position on a frame by frame basis. Used for first location update and when resuming tracking mode.
+     Call this method when you are doing custom zoom animations, this will make sure the puck stays on the route during these animations.
+     */
+    @objc public func enableFrameByFrameCourseViewTracking(for duration: TimeInterval) {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.disableFrameByFramePositioning), object: nil)
         perform(#selector(self.disableFrameByFramePositioning), with: nil, afterDelay: duration)
         self.shouldPositionCourseViewFrameByFrame = true
     }
-    
-    // MARK: - User Tracking
     
     @objc fileprivate func disableFrameByFramePositioning() {
         self.shouldPositionCourseViewFrameByFrame = false


### PR DESCRIPTION
This is a followup for #27. While the puck stays on the route line while manually panning the map, it still veers of when running animations (like zoom to the whole route). For these kinds of animations, implementers can now call the `enableFrameByFrameCourseViewTracking` from outside of the `NavigationMapView` to fix special cases like this. 