### PR TITLE
Only require background audio when using speech synthesis

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -86,8 +86,6 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     override public init() {
         super.init()
 
-        self.verifyBackgroundAudio()
-
         self.speechSynth.delegate = self
         
         self.resumeNotifications()
@@ -193,6 +191,9 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
      - parameter ignoreProgress: A `Bool` that indicates if the routeProgress is added to the instruction.
      */
     open func speak(_ instruction: SpokenInstruction, with locale: Locale?, ignoreProgress: Bool = false) {
+        // Don't require background audio unless the implementer is actually using speech APIs
+        self.verifyBackgroundAudio()
+
         if self.speechSynth.isSpeaking, let lastSpokenInstruction {
             self.voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction)
         }


### PR DESCRIPTION
Fixes #63

I'm not currently using voice instructions. I'd like to add it at some point, but my app is still useful without this feature.

The SDK requires the background "Audio" entitlement at runtime, but without the voice instructions, there's no reason for the background "Audio" entitlement.

The AppStore may not accept an application with the background audio entitlement that doesn't actually use background audio. (speaking from experience here 😬)

RouteVoiceController.verifyBackgroundAudio is called upon init, which happens when instantiating a NavigationViewController. Instead we should wait until we actually use the audio before verifying this permission.

