### PR TITLE
Fix: waypoint `didArrive:` is never called if audio instructions are not enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     #endif
     ```
 * Custom location snapping in the `RouteController` via the delegate
+* Fix: If the directions API endpoint doesn't include audio instructions, `didArrive:` would never be called.
+  * Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/72>
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -429,19 +429,23 @@ extension RouteController: CLLocationManagerDelegate {
 
     func updateRouteLegProgress(for location: CLLocation) {
         let currentDestination = self.routeProgress.currentLeg.destination
-        guard let remainingVoiceInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
+        guard self.routeProgress.currentLegProgress.remainingSteps.count == 0 else { return }
 
-        if self.routeProgress.currentLegProgress.remainingSteps.count <= 1, remainingVoiceInstructions.count == 0, currentDestination != self.previousArrivalWaypoint {
-            self.previousArrivalWaypoint = currentDestination
+        if let remainingSpokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions {
+            guard remainingSpokenInstructions.count == 0 else { return }
+        }
 
-            self.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+        guard currentDestination != self.previousArrivalWaypoint else { return }
 
-            let advancesToNextLeg = self.delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
+        self.previousArrivalWaypoint = currentDestination
 
-            if !self.routeProgress.isFinalLeg, advancesToNextLeg {
-                self.routeProgress.legIndex += 1
-                self.updateDistanceToManeuver()
-            }
+        self.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+
+        let advancesToNextLeg = self.delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
+
+        if !self.routeProgress.isFinalLeg, advancesToNextLeg {
+            self.routeProgress.legIndex += 1
+            self.updateDistanceToManeuver()
         }
     }
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -429,23 +429,22 @@ extension RouteController: CLLocationManagerDelegate {
 
     func updateRouteLegProgress(for location: CLLocation) {
         let currentDestination = self.routeProgress.currentLeg.destination
-        guard self.routeProgress.currentLegProgress.remainingSteps.count == 0 else { return }
-
-        if let remainingSpokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions {
-            guard remainingSpokenInstructions.count == 0 else { return }
+        var hasRemainingVoiceInstructions = false
+        if let remainingVoiceInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions, remainingVoiceInstructions.count > 0 {
+            hasRemainingVoiceInstructions = true
         }
 
-        guard currentDestination != self.previousArrivalWaypoint else { return }
+        if self.routeProgress.currentLegProgress.remainingSteps.count <= 1, !hasRemainingVoiceInstructions, currentDestination != self.previousArrivalWaypoint {
+            self.previousArrivalWaypoint = currentDestination
 
-        self.previousArrivalWaypoint = currentDestination
+            self.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
 
-        self.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+            let advancesToNextLeg = self.delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
 
-        let advancesToNextLeg = self.delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
-
-        if !self.routeProgress.isFinalLeg, advancesToNextLeg {
-            self.routeProgress.legIndex += 1
-            self.updateDistanceToManeuver()
+            if !self.routeProgress.isFinalLeg, advancesToNextLeg {
+                self.routeProgress.legIndex += 1
+                self.updateDistanceToManeuver()
+            }
         }
     }
 


### PR DESCRIPTION
(Note: this was extracted from #58, [as requested](https://github.com/maplibre/maplibre-navigation-ios/pull/58#issuecomment-2169220841))

Previously, we would never "arrive" at a waypoint if the route didn't
include spoken instructions. Now we only consider spoken instructions if
there were any present in the first place. I assume this was just a bug, maybe
because people were testing on the mapbox API which provides voice
instructions by default?

Previously, we would "arrive" at the second-to-last step, rather than at
the final step. This bug is more mysterious — I'm not sure how it could
have passed QA. Maybe mapbox provides/provided an additional zero length
step or something at the end of their instructions? I've tested this with my own API and Mapbox's directions API and both seem to perform reasonably now.

Note that "arrival" has some slop in it, see RouteControllerManeuverZoneRadius (default 40 meters).