### PR TITLE
Restore the ability to init NavVC without animations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,14 @@
 
 ## Unreleased
 * Start & Stop Navigation in existing Map
-    - Removed: `NavigationViewController(for route: Route, dayStyle: Style, routeController: RouteController? = nil, locationManager: NavigationLocationManager? = nil, voiceController: RouteVoiceController? = nil)` use `NavigationViewController(dayStyleURL: URL, nightStyleURL: URL? = nil,directions: Directions = .shared, voiceController: RouteVoiceController = RouteVoiceController())` followed by `startNavigation(with route: Route)` instead.
-    - To simulate a route, pass a `SimulatedLocationManager` to `startNavigation()` function: 
+    - Removed: `NavigationViewController(for route: Route, dayStyle: Style, routeController: RouteController? = nil, locationManager: NavigationLocationManager? = nil, voiceController: RouteVoiceController? = nil)` use `NavigationViewController(dayStyleURL: URL, nightStyleURL: URL? = nil,directions: Directions = .shared, voiceController: RouteVoiceController = RouteVoiceController())` followed by `startNavigation(with route: Route, animated: Bool)` instead.
+    - To simulate a route, pass a `SimulatedLocationManager` to `startNavigation()` function:
 
     ```swift
     let vc = NavigationViewController(dayStyleURL: AppConfig().tileserverStyleUrl)
-
-    if Env.current.simulateLocationForTesting {
-        let simulatedLocationManager = SimulatedLocationManager(route: route)
-        simulatedLocationManager.speedMultiplier = 5
-        vc.startNavigation(with: route, locationManager: simulatedLocationManager)
-    } else {
-        vc.startNavigation(with: route)
-    }
+    let simulatedLocationManager = SimulatedLocationManager(route: route)
+    simulatedLocationManager.speedMultiplier = 5
+    vc.startNavigation(with: route, animated: false, locationManager: simulatedLocationManager)
     ```
 
 ## 3.0.0 (Jun 15, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
     - To simulate a route, pass a `SimulatedLocationManager` to `startNavigation()` function:
 
     ```swift
-    let vc = NavigationViewController(dayStyleURL: AppConfig().tileserverStyleUrl)
-    let simulatedLocationManager = SimulatedLocationManager(route: route)
-    simulatedLocationManager.speedMultiplier = 5
-    vc.startNavigation(with: route, animated: false, locationManager: simulatedLocationManager)
+    #if targetEnvironment(simulator) 
+        let locationManager = SimulatedLocationManager(route: route)
+        locationManager.speedMultiplier = 2
+        self.startNavigation(with: route, animated: false, locationManager: locationManager)
+    #else
+        self.startNavigation(with: route, animated: false)
+    #endif
     ```
 
 ## 3.0.0 (Jun 15, 2024)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -422,7 +422,7 @@ open class NavigationViewController: UIViewController {
     
     // MARK: - NavigationViewController
 	
-    public func startNavigation(with route: Route, routeController: RouteController? = nil, locationManager: NavigationLocationManager? = nil) {
+    public func startNavigation(with route: Route, animated: Bool, routeController: RouteController? = nil, locationManager: NavigationLocationManager? = nil) {
         if let locationManager {
             self.locationManager = locationManager
         }
@@ -431,7 +431,7 @@ open class NavigationViewController: UIViewController {
         }
         self.route = route
 		
-        self.mapViewController.navigationView.showUI(animated: true)
+        self.mapViewController.navigationView.showUI(animated: animated)
         self.mapViewController.destination = route.legs.last?.destination
 
         self.routeController?.usesDefaultUserInterface = true
@@ -496,8 +496,8 @@ open class NavigationViewController: UIViewController {
                 let directions = routeController.directions
                 let route = routeController.routeProgress.route
                 let navigationViewController = NavigationViewController(dayStyle: DayStyle(demoStyle: ()), nightStyle: NightStyle(demoStyle: ()), directions: directions)
-                navigationViewController.startNavigation(with: route, routeController: routeController, locationManager: locationManager)
-                
+                navigationViewController.startNavigation(with: route, animated: true, routeController: routeController, locationManager: locationManager)
+
                 window.rootViewController?.topMostViewController()?.present(navigationViewController, animated: true, completion: {
                     navigationViewController.isUsedInConjunctionWithCarPlayWindow = true
                 })

--- a/MapboxNavigationTests/Sources/Tests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/Sources/Tests/NavigationViewControllerTests.swift
@@ -21,8 +21,8 @@ class NavigationViewControllerTests: XCTestCase {
                                            voiceController: voice)
         
         nav.delegate = self
-        nav.startNavigation(with: self.initialRoute, locationManager: SimulatedLocationManager(route: self.initialRoute))
-        
+        nav.startNavigation(with: self.initialRoute, animated: false, locationManager: SimulatedLocationManager(route: self.initialRoute))
+
         let routeController = nav.routeController!
         let firstCoord = routeController.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let firstLocation = location(at: firstCoord)
@@ -92,7 +92,7 @@ class NavigationViewControllerTests: XCTestCase {
         let navigationViewController = NavigationViewController(dayStyle: DayStyle(demoStyle: ()),
                                                                 directions: fakeDirections,
                                                                 voiceController: FakeVoiceController())
-        navigationViewController.startNavigation(with: self.initialRoute, locationManager: SimulatedLocationManager(route: self.initialRoute))
+        navigationViewController.startNavigation(with: self.initialRoute, animated: false, locationManager: SimulatedLocationManager(route: self.initialRoute))
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -109,7 +109,7 @@ class NavigationViewControllerTests: XCTestCase {
     // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
         let navigationViewController = NavigationViewController(dayStyle: DayStyle(demoStyle: ()), directions: fakeDirections, voiceController: FakeVoiceController())
-        navigationViewController.startNavigation(with: self.initialRoute, locationManager: SimulatedLocationManager(route: self.initialRoute))
+        navigationViewController.startNavigation(with: self.initialRoute, animated: false, locationManager: SimulatedLocationManager(route: self.initialRoute))
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -125,7 +125,7 @@ class NavigationViewControllerTests: XCTestCase {
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
         let navigationViewController = NavigationViewController(dayStyle: DayStyle(demoStyle: ()), nightStyle: NightStyle(demoStyle: ()), directions: fakeDirections, voiceController: FakeVoiceController())
-        navigationViewController.startNavigation(with: self.initialRoute, locationManager: SimulatedLocationManager(route: self.initialRoute))
+        navigationViewController.startNavigation(with: self.initialRoute, animated: false, locationManager: SimulatedLocationManager(route: self.initialRoute))
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -179,11 +179,11 @@ class NavigationViewControllerTests: XCTestCase {
     
     func testDestinationAnnotationUpdatesUponReroute() {
         let styleLoaded = XCTestExpectation(description: "Style Loaded")
-        let navigationViewController = NavigationViewControllerTestable(for: initialRoute, dayStyle: DayStyle.blankStyleForTesting, styleLoaded: styleLoaded)
+        let navigationViewController = NavigationViewControllerTestable(dayStyle: DayStyle.blankStyleForTesting, styleLoaded: styleLoaded)
 
         // wait for the style to load -- routes won't show without it.
         wait(for: [styleLoaded], timeout: 5)
-        navigationViewController.startNavigation(with: self.initialRoute, locationManager: SimulatedLocationManager(route: self.initialRoute))
+        navigationViewController.startNavigation(with: self.initialRoute, animated: false, locationManager: SimulatedLocationManager(route: self.initialRoute))
 
         runUntil {
             !(navigationViewController.mapView.annotations?.isEmpty ?? true)
@@ -255,12 +255,10 @@ private extension NavigationViewControllerTests {
 class NavigationViewControllerTestable: NavigationViewController {
     var styleLoadedExpectation: XCTestExpectation
    
-    required init(for route: Route,
-                  dayStyle: Style,
+    required init(dayStyle: Style,
                   styleLoaded: XCTestExpectation) {
         self.styleLoadedExpectation = styleLoaded
         super.init(dayStyle: dayStyle, directions: Directions(accessToken: "abc", host: ""), voiceController: FakeVoiceController())
-        self.startNavigation(with: route)
     }
     
     @objc(initWithRoute:dayStyle:nightStyle:directions:routeController:locationManager:voiceController:)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Start the navigation by calling `startNavigation(with: route)`. If you want to s
 #if targetEnvironment(simulator) 
     let locationManager = SimulatedLocationManager(route: route)
     locationManager.speedMultiplier = 2
-    self.startNavigation(with: route, locationManager: locationManager)
+    self.startNavigation(with: route, animated: false, locationManager: locationManager)
 #else
-    self.startNavigation(with: route)
+    self.startNavigation(with: route, animated: false)
 #endif
 ```
 


### PR DESCRIPTION
Prior to #54, the NavigationViewController could only be used modally.

With #54, you can switch between "map mode" and "navigation mode". 

An animation was introduced in `navigationView.showUI` for the sake of smoothly transitioning from "map mode" to "navigation mode".

However, if you are still using the NavigationViewController modally, this animation might interfere with other things you were doing - like zooming before presentation.
