### PR TITLE
Fix tests on german machine

### DIFF
--- a/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/MapboxCoreNavigation/DistanceFormatter.swift
@@ -223,9 +223,9 @@ open class DistanceFormatter: LengthFormatter {
     @available(iOS 10.0, *)
     @objc(measurementOfDistance:)
     public func measurement(of distance: CLLocationDistance) -> Measurement<UnitLength> {
-        let threshold = threshold(for: distance)
-        numberFormatter.maximumFractionDigits = threshold.maximumFractionDigits
-        numberFormatter.roundingIncrement = threshold.roundingIncrement as NSNumber
+        let threshold = self.threshold(for: distance)
+        self.numberFormatter.maximumFractionDigits = threshold.maximumFractionDigits
+        self.numberFormatter.roundingIncrement = threshold.roundingIncrement as NSNumber
         self.unit = threshold.unit
         return threshold.measurement(for: distance)
     }

--- a/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/MapboxCoreNavigation/DistanceFormatter.swift
@@ -131,6 +131,16 @@ open class DistanceFormatter: LengthFormatter {
     
     /// Indicates the most recently used unit
     public private(set) var unit: LengthFormatter.Unit = .millimeter
+	
+    public var locale: Locale {
+        set {
+            self.numberFormatter.locale = newValue
+            self.nonFractionalLengthFormatter.numberFormatter.locale = newValue
+        }
+        get {
+            self.numberFormatter.locale
+        }
+    }
 
     // Rounding tables for metric, imperial, and UK measurement systems. The last threshold is used as a default.
     lazy var roundingTableMetric: RoundingTable = .init(thresholds: [.init(maximumDistance: 25, roundingIncrement: 5, unit: .meter, maximumFractionDigits: 0),
@@ -157,17 +167,21 @@ open class DistanceFormatter: LengthFormatter {
     @objc public init(approximate: Bool = false) {
         self.approx = approximate
         super.init()
-        numberFormatter.locale = .nationalizedCurrent
+        self.locale = .nationalizedCurrent
     }
     
     public required init?(coder decoder: NSCoder) {
         self.approx = decoder.decodeBool(forKey: "approximate")
         super.init(coder: decoder)
+		
+        let localeIdentifier = (decoder.decodeObject(of: NSString.self, forKey: "locale") as? String)!
+        self.locale = Locale(identifier: localeIdentifier)
     }
     
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         aCoder.encode(self.approx, forKey: "approximate")
+        aCoder.encode(self.locale.identifier, forKey: "locale")
     }
     
     func threshold(for distance: CLLocationDistance) -> RoundingTable.Threshold {

--- a/MapboxCoreNavigationTests/DistanceFormatterTests.swift
+++ b/MapboxCoreNavigationTests/DistanceFormatterTests.swift
@@ -44,8 +44,6 @@ class DistanceFormatterTests: XCTestCase {
     func testDistanceFormatters_US() {
         NavigationSettings.shared.distanceUnit = .mile
         self.distanceFormatter.locale = Locale(identifier: "en-US")
-//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-US")
-        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "en-US")
         
         self.assertDistance(0, displayed: "0 ft", quantity: "0")
         self.assertDistance(oneFeet * 50, displayed: "50 ft", quantity: "50")
@@ -66,8 +64,6 @@ class DistanceFormatterTests: XCTestCase {
     func testDistanceFormatters_DE() {
         NavigationSettings.shared.distanceUnit = .kilometer
         self.distanceFormatter.locale = Locale(identifier: "de-DE")
-//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
-        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
         
         self.assertDistance(0, displayed: "0 m", quantity: "0")
         self.assertDistance(4, displayed: "5 m", quantity: "5")
@@ -92,8 +88,6 @@ class DistanceFormatterTests: XCTestCase {
     func testDistanceFormatters_GB() {
         NavigationSettings.shared.distanceUnit = .mile
         self.distanceFormatter.locale = Locale(identifier: "en-GB")
-//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
-        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
         
         self.assertDistance(0, displayed: "0 yd", quantity: "0")
         self.assertDistance(oneYard * 4, displayed: "0 yd", quantity: "0")

--- a/MapboxCoreNavigationTests/DistanceFormatterTests.swift
+++ b/MapboxCoreNavigationTests/DistanceFormatterTests.swift
@@ -13,37 +13,39 @@ class DistanceFormatterTests: XCTestCase {
         super.setUp()
     }
     
-    func assertDistance(_ distance: CLLocationDistance, displayed: String, quantity: String) {
+    func assertDistance(_ distance: CLLocationDistance, displayed: String, quantity: String, file: StaticString = #file, line: UInt = #line) {
         let displayedString = self.distanceFormatter.string(from: distance)
-        XCTAssertEqual(displayedString, displayed, "Displayed: '\(displayedString)' should be equal to \(displayed)")
+        XCTAssertEqual(displayedString, displayed, "Displayed: '\(displayedString)' should be equal to \(displayed)", file: file, line: line)
         
         let attributedString = self.distanceFormatter.attributedString(for: distance as NSNumber)
-        XCTAssertEqual(attributedString?.string, displayed, "Displayed: '\(attributedString?.string ?? "")' should be equal to \(displayed)")
+        XCTAssertEqual(attributedString?.string, displayed, "Displayed: '\(attributedString?.string ?? "")' should be equal to \(displayed)", file: file, line: line)
         guard let checkedAttributedString = attributedString else {
             return
         }
         
         let quantityRange = checkedAttributedString.string.range(of: quantity)
-        XCTAssertNotNil(quantityRange, "Displayed: '\(checkedAttributedString.string)' should contain \(quantity)")
+        XCTAssertNotNil(quantityRange, "Displayed: '\(checkedAttributedString.string)' should contain \(quantity)", file: file, line: line)
         guard let checkedQuantityRange = quantityRange else {
             return
         }
         
         var effectiveQuantityRange = NSRange(location: NSNotFound, length: 0)
         let quantityAttrs = checkedAttributedString.attributes(at: checkedQuantityRange.lowerBound.utf16Offset(in: checkedAttributedString.string), effectiveRange: &effectiveQuantityRange)
-        XCTAssertEqual(quantityAttrs[NSAttributedString.Key.quantity] as? NSNumber, distance as NSNumber, "'\(quantity)' should have quantity \(distance)")
-        XCTAssertEqual(effectiveQuantityRange.length, quantity.count)
+        XCTAssertEqual(quantityAttrs[NSAttributedString.Key.quantity] as? NSNumber, distance as NSNumber, "'\(quantity)' should have quantity \(distance)", file: file, line: line)
+        XCTAssertEqual(effectiveQuantityRange.length, quantity.count, file: file, line: line)
         
         guard checkedQuantityRange.upperBound.utf16Offset(in: checkedAttributedString.string) < checkedAttributedString.length else {
             return
         }
         let unitAttrs = checkedAttributedString.attributes(at: checkedQuantityRange.upperBound.utf16Offset(in: checkedAttributedString.string), effectiveRange: nil)
-        XCTAssertNil(unitAttrs[NSAttributedString.Key.quantity], "Unit should not be emphasized like a quantity")
+        XCTAssertNil(unitAttrs[NSAttributedString.Key.quantity], "Unit should not be emphasized like a quantity", file: file, line: line)
     }
     
     func testDistanceFormatters_US() {
         NavigationSettings.shared.distanceUnit = .mile
-        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-US")
+        self.distanceFormatter.locale = Locale(identifier: "en-US")
+//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-US")
+        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "en-US")
         
         self.assertDistance(0, displayed: "0 ft", quantity: "0")
         self.assertDistance(oneFeet * 50, displayed: "50 ft", quantity: "50")
@@ -63,7 +65,9 @@ class DistanceFormatterTests: XCTestCase {
     
     func testDistanceFormatters_DE() {
         NavigationSettings.shared.distanceUnit = .kilometer
-        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
+        self.distanceFormatter.locale = Locale(identifier: "de-DE")
+//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
+        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
         
         self.assertDistance(0, displayed: "0 m", quantity: "0")
         self.assertDistance(4, displayed: "5 m", quantity: "5")
@@ -79,15 +83,17 @@ class DistanceFormatterTests: XCTestCase {
         self.assertDistance(999, displayed: "1 km", quantity: "1")
         self.assertDistance(1000, displayed: "1 km", quantity: "1")
         self.assertDistance(1001, displayed: "1 km", quantity: "1")
-        self.assertDistance(2500, displayed: "2.5 km", quantity: "2.5")
-        self.assertDistance(2900, displayed: "2.9 km", quantity: "2.9")
+        self.assertDistance(2500, displayed: "2,5 km", quantity: "2,5")
+        self.assertDistance(2900, displayed: "2,9 km", quantity: "2,9")
         self.assertDistance(3000, displayed: "3 km", quantity: "3")
         self.assertDistance(3500, displayed: "4 km", quantity: "4")
     }
     
     func testDistanceFormatters_GB() {
         NavigationSettings.shared.distanceUnit = .mile
-        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
+        self.distanceFormatter.locale = Locale(identifier: "en-GB")
+//        self.distanceFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
+        //		self.distanceFormatter.nonFractionalLengthFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
         
         self.assertDistance(0, displayed: "0 yd", quantity: "0")
         self.assertDistance(oneYard * 4, displayed: "0 yd", quantity: "0")


### PR DESCRIPTION
### Description

When running tests on a non-English Mac computer, some tests related to the decimal separator do not pass.

### Open Tasks

- [x] Keep locale synced in both number formatters

### Infos for Reviewer

Turns out we use 2 NumberFormatter and their locale is not synced. This PR fixes this.