### PR TITLE
Open RouteController to custom location snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         self.startNavigation(with: route, animated: false)
     #endif
     ```
+* Custom location snapping in the `RouteController` via the delegate
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -230,7 +230,13 @@ open class RouteController: NSObject, Router {
      - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
      */
     var snappedLocation: CLLocation? {
-        self.rawLocation?.snapped(to: self.routeProgress.currentLegProgress)
+        let snappedDefault = self.rawLocation?.snapped(to: self.routeProgress.currentLegProgress)
+        guard let raw = self.rawLocation else { return snappedDefault }
+
+        let snappedCustom = self.delegate?.routeControllerSnap?(
+            rawLocation: raw,
+            snappedByDefaultTo: snappedDefault)
+        return snappedCustom  ?? snappedDefault
     }
 
     var heading: CLHeading?

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -230,13 +230,12 @@ open class RouteController: NSObject, Router {
      - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
      */
     var snappedLocation: CLLocation? {
-        let snappedDefault = self.rawLocation?.snapped(to: self.routeProgress.currentLegProgress)
-        guard let raw = self.rawLocation else { return snappedDefault }
+        guard let raw = self.rawLocation else {
+            return nil
+        }
 
-        let snappedCustom = self.delegate?.routeControllerSnap?(
-            rawLocation: raw,
-            snappedByDefaultTo: snappedDefault)
-        return snappedCustom  ?? snappedDefault
+        let customSnap = self.delegate?.routeControllerSnap?(rawLocation: raw)
+        return customSnap ?? raw.snapped(to: self.routeProgress.currentLegProgress)
     }
 
     var heading: CLHeading?

--- a/MapboxCoreNavigation/RouteControllerDelegate.swift
+++ b/MapboxCoreNavigation/RouteControllerDelegate.swift
@@ -132,6 +132,6 @@ public protocol RouteControllerDelegate: AnyObject {
         - parameter rawLocation: The raw location from the controller
         - returns: The snapped location or nil if snapping were impossible.
      */
-    @objc(routeControllerSnapLocation:snappedByDefaultTo:)
-    optional func routeControllerSnap(rawLocation: CLLocation, snappedByDefaultTo snappedLocation: CLLocation?) -> CLLocation?
+    @objc(routeControllerSnapLocation:)
+    optional func routeControllerSnap(rawLocation: CLLocation) -> CLLocation?
 }

--- a/MapboxCoreNavigation/RouteControllerDelegate.swift
+++ b/MapboxCoreNavigation/RouteControllerDelegate.swift
@@ -125,4 +125,13 @@ public protocol RouteControllerDelegate: AnyObject {
       */
     @objc(routeControllerGetDirections:along:completion:)
     optional func routeControllerGetDirections(from location: CLLocation, along progress: RouteProgress, completion: @escaping (_ mostSimilarRoute: Route?, _ routes: [Route]?, _ error: Error?) -> Void) -> Bool
+
+    /**
+     Allows to customize the snapping of raw and pre-snapped location. If no implementation is provided, the default snapping will be used.
+
+        - parameter rawLocation: The raw location from the controller
+        - returns: The snapped location or nil if snapping were impossible.
+     */
+    @objc(routeControllerSnapLocation:snappedByDefaultTo:)
+    optional func routeControllerSnap(rawLocation: CLLocation, snappedByDefaultTo snappedLocation: CLLocation?) -> CLLocation?
 }


### PR DESCRIPTION
### Description

This PR opens the `RouteController.snappedLocation` to be additionally modified by delegate implementers.
This is useful to plug in a custom snapping logic.

### Infos for Reviewer

The intention was to open up the snapping logic but make it optional and don't change snapping behavior if custom logic is not provided. If custom snapping doesn't provide a valid value (ie. fails), the default snapping shall be used as fallback.