### PR TITLE
Add reminder to add changelog entry to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
+### Checklist
+
+- [ ] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
+- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues
+
 ### Description
 
-
-
-### Open Tasks
-
-- [ ] 
 
 ### Infos for Reviewer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - To simulate a route, pass a `SimulatedLocationManager` to `startNavigation()` function:
 
     ```swift
-    #if targetEnvironment(simulator) 
+    #if targetEnvironment(simulator)
         let locationManager = SimulatedLocationManager(route: route)
         locationManager.speedMultiplier = 2
         self.startNavigation(with: route, animated: false, locationManager: locationManager)
@@ -19,6 +19,10 @@
   * Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/72>
 * Updated "turf" geometry library from 0.2.2 to 2.8.0
     * Merged in https://github.com/maplibre/maplibre-navigation-ios/pull/91
+* Only require background audio when using speech synthesis in https://github.com/maplibre/maplibre-navigation-ios/pull/64
+* Fix: Respond to changes in dynamic type without having to restart the app in https://github.com/maplibre/maplibre-navigation-ios/pull/65
+* Fix: crash in EndOfRouteViewController and restore its presentation by in https://github.com/maplibre/maplibre-navigation-ios/pull/71
+* Fix: retain cycles in RouteMapViewController
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.


### PR DESCRIPTION
As an alternative to #86 , let's remind people to decide if a changelog entry is warranted as part of their PR process, rather than automatically generating an entry for every PR in the changelog. 

This simple checklist approach has worked pretty well for me in practice for other projects.

Ultimately it's a judgement call between the PR author and the reviewer(s) if a changelog entry is warranted, but I expect the average outcome will be better this way vs. cluttering the changelog with updates that are not likely to be relevant to upgrading users.
