### PR TITLE
Position puck in lower portion of screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
     - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/47>
 * Fix: NavigationViewController displayed incorrect `speedMultiplier` when using SimulatedLocationManager
     - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/49>
+* Adjusted the camera during navigation to show more of what's "ahead" in the route - effectively moving the puck lower on the screen. As before, see `NavigationMapViewCourseTrackingDelegate.updateCamera(_:location:,routeProgress:)` if you want to customize this behavior.
+    - Merged in <https://github.com/maplibre/maplibre-navigation-ios/pull/92>
 
 ## v2.0.0 (May 23, 2023)
 * Upgrade minimum iOS version from 11.0 to 12.0.

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -293,7 +293,12 @@ open class NavigationMapView: MLNMapView, UIGestureRecognizerDelegate {
             if !cameraUpdated {
                 let newCamera = MLNMapCamera(lookingAtCenter: location.coordinate, acrossDistance: self.altitude, pitch: 45, heading: location.course)
                 let function = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
-                setCamera(newCamera, withDuration: 1, animationTimingFunction: function, edgePadding: UIEdgeInsets.zero, completionHandler: nil)
+
+                // Because it's more useful to show what's ahead than what's behind, we bias the camera to put
+                // the user location puck in the lower portion of the visible map, showing more of what's ahead.
+                let edgePadding = UIEdgeInsets(top: bounds.height * 0.4 - safeAreaInsets.bottom, left: 0, bottom: 0, right: 0)
+
+                setCamera(newCamera, withDuration: 1, animationTimingFunction: function, edgePadding: edgePadding, completionHandler: nil)
             }
         }
         


### PR DESCRIPTION
### Description

Fixes #80, as a partial alternative to #82.

@Patrick-Kladek - if I've missed something necessary for lowering the puck, please let me know. If the other changes in #82 are fixing other things, please re-scope #82 or follow up in a separate PR explaining the changes.

## Before

Puck is centered.

<img width="300" alt="puck-before-lowering" src="https://github.com/user-attachments/assets/dd52d45c-bbfc-4ff9-97ea-839da5cda969">


## After

Puck is lower.

<img width="300" alt="puck-lower-0 4" src="https://github.com/user-attachments/assets/af7eead4-f6e5-4f51-84aa-84a0c2a2f1d3">
<img width="600" alt="Screenshot 2024-08-07 at 14 46 50" src="https://github.com/user-attachments/assets/61adff2f-affb-41b2-9ad8-2a3cf386f432">

### iPhone SE
<img width="600" alt="Screenshot 2024-08-07 at 14 47 37" src="https://github.com/user-attachments/assets/3cc9b6c9-8cb0-4ef3-b4d5-b9f1b05a6fa6">
<img width="300" alt="Screenshot 2024-08-07 at 14 47 30" src="https://github.com/user-attachments/assets/196b7b80-87dc-43dc-8acd-96515f55c247">

