### PR TITLE
Cleanup: remove private header

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -258,9 +258,7 @@ open class NavigationMapView: MLNMapView, UIGestureRecognizerDelegate {
         }
     }
    
-    override open func mapViewDidFinishRenderingFrameFullyRendered(_ fullyRendered: Bool, frameEncodingTime: Double, frameRenderingTime: Double) {
-        super.mapViewDidFinishRenderingFrameFullyRendered(fullyRendered, frameEncodingTime: frameEncodingTime, frameRenderingTime: frameRenderingTime)
-        
+    func updateCourseTrackingAfterDidFinishRenderingFrame() {
         guard self.shouldPositionCourseViewFrameByFrame else { return }
         guard let location = userLocationForCourseTracking else { return }
         

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -582,6 +582,10 @@ extension RouteMapViewController: NavigationViewDelegate {
         self.delegate?.mapViewDidFinishLoadingMap?(mapView)
     }
 
+    func mapViewDidFinishRenderingFrame(_ mapView: MLNMapView, fullyRendered: Bool) {
+        self.mapView.updateCourseTrackingAfterDidFinishRenderingFrame()
+    }
+
     // MARK: - VisualInstructionDelegate
 	
     func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {

--- a/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.h
+++ b/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.h
@@ -1,9 +1,0 @@
-#import <MapLibre/Mapbox.h>
-
-@interface MLNMapView (MLNNavigationAdditions)
-
-- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered
-                                  frameEncodingTime:(double)frameEncodingTime
-                                 frameRenderingTime:(double)frameRenderingTime;
-
-@end

--- a/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.m
+++ b/MapboxNavigationObjc/MLNMapView+MLNNavigationAdditions.m
@@ -1,8 +1,0 @@
-#import "MLNMapView+MLNNavigationAdditions.h"
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wincomplete-implementation"
-@implementation MLNMapView (MLNNavigationAdditions)
-#pragma clang diagnostic pop
-
-@end

--- a/MapboxNavigationObjc/include/MapboxNavigation.h
+++ b/MapboxNavigationObjc/include/MapboxNavigation.h
@@ -7,4 +7,4 @@ FOUNDATION_EXPORT double MapboxNavigationVersionNumber;
 FOUNDATION_EXPORT const unsigned char MapboxNavigationVersionString[];
 
 #import "../MBRouteVoiceController.h"
-#import "../MLNMapView+MLNNavigationAdditions.h"
+#import <MapLibre/Mapbox.h>


### PR DESCRIPTION
### Description

This header was copied in from MapLibre Native to expose a private
method.

Previously this got out of sync and caused a bug:
https://github.com/maplibre/maplibre-navigation-ios/pull/53

Instead we can use the already public delegate method.

Note: The deleted header was importing Maplibre/Mapbox.h, but we are
using that elsewhere, so I moved that import up a level.


### Open Tasks

Related:
https://github.com/maplibre/maplibre-native/issues/2228
https://github.com/maplibre/maplibre-navigation-ios/pull/53

### Infos for Reviewer

There should be no change in behavior from this — just cleanup.