### PR TITLE
Hide LanesView on navigation start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix: Respond to changes in dynamic type without having to restart the app in https://github.com/maplibre/maplibre-navigation-ios/pull/65
 * Fix: crash in EndOfRouteViewController and restore its presentation by in https://github.com/maplibre/maplibre-navigation-ios/pull/71
 * Fix: retain cycles in RouteMapViewController
+* Fix: hide lanesView on navigation start
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -180,7 +180,6 @@ open class NavigationView: UIView {
     func showUI(animated: Bool = true) {
         let views: [UIView] = [
             self.instructionsBannerContentView,
-            self.lanesView,
             self.bottomBannerContentView,
             self.floatingStackView
         ]
@@ -199,7 +198,6 @@ open class NavigationView: UIView {
     func hideUI(animated: Bool = true) {
         let views: [UIView] = [
             self.instructionsBannerContentView,
-            self.lanesView,
             self.bottomBannerContentView,
             self.floatingStackView,
             self.resumeButton


### PR DESCRIPTION
### Checklist

- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description

Hide LaneView when Navigation is starting but make sure it shows up if the route contains lane information

### Tasks

- [x] don't hide LanesView by adjusting alpha value
- [x] let `update(for visualInstruction: VisualInstructionBanner?)` handle show & hide

### Infos for Reviewer

`NavigationView` has a function `showUI(animated: Bool = true)` which showed the LanesView even when the route doesn't contain lane information. This function was called when navigation starts, therefore the next step view was double in size. After the first turn this view was then correctly hidden.

Because the all other views animate via alpha value, this could lead to a state where the LanesView wouldn't show up, as `update(for visualInstruction: VisualInstructionBanner?)` only changed the `isHidden` property, alpha could be still zero, which would prevent the view from appearing.

I've used a route in Berlin using Mapbox API to obtain a route which I know contains lane information. This is a recording form our app, please note that our map style doesn't contain map data in this region, thats why it's empty. The route works regardless and the important part, showing the LanesView appearing is visible.

![364466824-d00dae8c-8981-4ea4-8f0f-592acfa260b3](https://github.com/user-attachments/assets/c9ae47f7-5b53-4414-8085-a674d2ccb40b)
