### PR TITLE
Work around type-checking error present in XCode 16.0

### DIFF
--- a/MapboxNavigation/Dictionary.swift
+++ b/MapboxNavigation/Dictionary.swift
@@ -20,6 +20,15 @@ extension [Int: Double] {
      Returns a copy of the stop dictionary with each value multiplied by the given factor.
      */
     func multiplied(by factor: Double) -> Dictionary {
-        mapValues { $0 * factor }
+        // This assignment should be a no-op, but it avoids hitting a type checking error I'm seeing in XCode Version 16.0 (16A242d) (stable release)
+        // I did not experience this error on XCode 15.4
+        //
+        // The error is:
+        // > Cannot convert return expression of type 'Dictionary<Int, Double>' to return type 'Dictionary<String, Optional<JSONValue>>.RawValue' (aka 'Dictionary<String, Optional<Any>>')
+        //
+        // JSONValue is defined in turf.
+        // Maybe the complexity of the various expressible-by-literal's in JSONValue/JSONObject are leading to a compiler edgecase? Just a guess.
+        let tmp = mapValues { $0 * factor }
+        return tmp
     }
 }


### PR DESCRIPTION
I started seeing this immediately upon upgrading to the stable release of XCode 16.0

The error is:
> Cannot convert return expression of type 'Dictionary<Int, Double>' to return type 'Dictionary<String, Optional<JSONValue>>.RawValue' (aka 'Dictionary<String, Optional<Any>>')

This assignment should be a no-op, but it avoids hitting the error. This seems like a swift/xcode bug, but the work around is harmless enough.

## Context

`JSONValue` (mentioned in the error message) is defined in turf.

Maybe the complexity of the various expressible-by-literal's in JSONValue/JSONObject are leading to a compiler edge case? Just a wild guess.