### PR TITLE
Updated MapLibre Native dependency to ios-v6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
 ## Unreleased
+* Updated MapLibre Native dependency to ios-v6.9.0 (https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.9.0).
 * Start & Stop Navigation in existing Map
     - Removed: `NavigationViewController(for route: Route, dayStyle: Style, routeController: RouteController? = nil, locationManager: NavigationLocationManager? = nil, voiceController: RouteVoiceController? = nil)` use `NavigationViewController(dayStyleURL: URL, nightStyleURL: URL? = nil,directions: Directions = .shared, voiceController: RouteVoiceController = RouteVoiceController())` followed by `startNavigation(with route: Route, animated: Bool)` instead.
     - To simulate a route, pass a `SimulatedLocationManager` to `startNavigation()` function:

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3df876f8f2c6c591b0f66a29b3e216020afc885c",
-        "version" : "6.0.0"
+        "revision" : "93cb32c95b48f62edb27c75792038849cdfdaa35",
+        "version" : "6.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/flitsmeister/mapbox-directions-swift", exact: "0.23.3"),
         .package(url: "https://github.com/mapbox/turf-swift.git", from: "2.8.0"),
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.0.0"),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.9.0"),
         .package(url: "https://github.com/ceeK/Solar.git", exact: "3.0.1"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.6")
     ],


### PR DESCRIPTION
### Checklist

- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description
Updated from 6.5.0 to 6.9.0 (newest). Changes: https://github.com/maplibre/maplibre-native/compare/ios-v6.5.0...ios-v6.9.0
