### PR TITLE
Fix @unchecked Sendable warnings

### DIFF
--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -14,7 +14,7 @@ private let minimumTurnPenalty: CLLocationDirection = 0
 // Go maximum speed if distance to nearest coordinate is >= `safeDistance`
 private let safeDistance: CLLocationDistance = 50
 
-private class SimulatedLocation: CLLocation {
+private class SimulatedLocation: CLLocation, @unchecked Sendable {
     var turnPenalty: Double = 0
     
     override var description: String {

--- a/MapboxCoreNavigationTests/Support/DummyURLSessionDataTask.swift
+++ b/MapboxCoreNavigationTests/Support/DummyURLSessionDataTask.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class DummyURLSessionDataTask: URLSessionDataTask {
+class DummyURLSessionDataTask: URLSessionDataTask, @unchecked Sendable {
     override func resume() {
         //
     }

--- a/MapboxNavigation/ImageDownload.swift
+++ b/MapboxNavigation/ImageDownload.swift
@@ -12,7 +12,7 @@ protocol ImageDownload: URLSessionDataDelegate {
     var isFinished: Bool { get }
 }
 
-class ImageDownloadOperation: Operation, ImageDownload {
+class ImageDownloadOperation: Operation, ImageDownload, @unchecked Sendable {
     override var isConcurrent: Bool {
         true
     }


### PR DESCRIPTION
```
/Users/bolsinga/Documents/code/git/maplibre-navigation-ios/MapboxCoreNavigation/SimulatedLocationManager.swift:17:15: warning: class 'SimulatedLocation' must restate inherited '@unchecked Sendable' conformance
private class SimulatedLocation: CLLocation {
              ^
```

```
/Users/bolsinga/Documents/code/git/maplibre-navigation-ios/MapboxNavigation/ImageDownload.swift:15:7: warning: class 'ImageDownloadOperation' must restate inherited '@unchecked Sendable' conformance
class ImageDownloadOperation: Operation, ImageDownload {
      ^
```

```
/Users/bolsinga/Documents/code/git/maplibre-navigation-ios/MapboxCoreNavigationTests/Support/DummyURLSessionDataTask.swift:3:7: warning: class 'DummyURLSessionDataTask' must restate inherited '@unchecked Sendable' conformance
class DummyURLSessionDataTask: URLSessionDataTask {
      ^
```

`Sendable` is compatible with iOS 8. This project's `Package.swift` appears to have a minimum deployment of iOS 12. See https://developer.apple.com/documentation/swift/sendable

### Checklist

- [ ] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description
I saw these simple to fix compiler warnings the first time I built the project.

### Infos for Reviewer

