### PR TITLE
[FIX] Missing argument for parameter `frame` for `NavigationMapView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix: crash in EndOfRouteViewController and restore its presentation by in https://github.com/maplibre/maplibre-navigation-ios/pull/71
 * Fix: retain cycles in RouteMapViewController
 * Fix: hide lanesView on navigation start
+* Fix: add missing `frame` argument to `NavigationMapView` initializer
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -37,7 +37,7 @@ class CarPlayMapViewController: UIViewController, MLNMapViewDelegate {
     }()
     
     override func loadView() {
-        let mapView = NavigationMapView()
+        let mapView = NavigationMapView(frame: UIScreen.main.bounds)
         mapView.delegate = self
 //        mapView.navigationMapDelegate = self
         mapView.logoView.isHidden = true


### PR DESCRIPTION
### Checklist

- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [x] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description
The missing frame error is fixed. See issue: https://github.com/maplibre/maplibre-navigation-ios/issues/111

### Infos for Reviewer

