### PR TITLE
[FIX] Avoid iOS 26 naming conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix: crash in EndOfRouteViewController and restore its presentation by in https://github.com/maplibre/maplibre-navigation-ios/pull/71
 * Fix: retain cycles in RouteMapViewController
 * Fix: hide lanesView on navigation start
+* Fix: avoid iOS 26 name conflict
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/MapboxNavigation/DashedLineView.swift
+++ b/MapboxNavigation/DashedLineView.swift
@@ -4,8 +4,8 @@ import UIKit
 @IBDesignable
 @objc(MBDashedLineView)
 public class DashedLineView: LineView {
-    @IBInspectable public var dashedLength: CGFloat = 4 { didSet { self.updateProperties() } }
-    @IBInspectable public var dashedGap: CGFloat = 4 { didSet { self.updateProperties() } }
+    @IBInspectable public var dashedLength: CGFloat = 4 { didSet { self.updateDashedLineProperties() } }
+    @IBInspectable public var dashedGap: CGFloat = 4 { didSet { self.updateDashedLineProperties() } }
 
     let dashedLineLayer = CAShapeLayer()
 
@@ -13,10 +13,10 @@ public class DashedLineView: LineView {
         if self.dashedLineLayer.superlayer == nil {
             layer.addSublayer(self.dashedLineLayer)
         }
-        self.updateProperties()
+        self.updateDashedLineProperties()
     }
 
-    func updateProperties() {
+    private func updateDashedLineProperties() {
         let path = UIBezierPath()
         path.move(to: CGPoint(x: 0, y: bounds.height / 2))
         path.addLine(to: CGPoint(x: bounds.width, y: bounds.height / 2))


### PR DESCRIPTION
### Checklist

- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description
In iOS26 there is a new method `updateProperties()` introduced in `UIView`, so the custom one from the package should be renamed as we don't want to override the UIKit one

### Infos for Reviewer
It should build with Xcode 26
