### PR TITLE
Bump mapbox-directions-swift to 0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix: hide lanesView on navigation start
 * Fix: avoid iOS 26 name conflict
 * Fix: add missing `frame` argument to `NavigationMapView` initializer
+* Bump `mapbox-directions-swift` to 0.23.4 for route leg notifications support
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/flitsmeister/mapbox-directions-swift",
       "state" : {
-        "revision" : "6c19ecc4e1324887ae3250802b8d13d8d8b3ff2d",
-        "version" : "0.23.3"
+        "revision" : "8c5b9a55a00c9ba34526bd97795d413403a602d1",
+        "version" : "0.23.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/flitsmeister/mapbox-directions-swift", exact: "0.23.3"),
+        .package(url: "https://github.com/flitsmeister/mapbox-directions-swift", exact: "0.23.4"),
         .package(url: "https://github.com/flitsmeister/turf-swift", exact: "0.2.2"),
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.0.0"),
         .package(url: "https://github.com/ceeK/Solar.git", exact: "3.0.1"),


### PR DESCRIPTION
## Summary
- Bump `mapbox-directions-swift` from `0.23.3` to `0.23.4`
- Adds support for route leg notifications (`RouteNotification`) from the Directions API

Release: https://github.com/flitsmeister/mapbox-directions-swift/releases/tag/0.23.4

Made with [Cursor](https://cursor.com)