### PR TITLE
Prepare 4.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
 * Fix: hide lanesView on navigation start
 * Fix: avoid iOS 26 name conflict
 * Fix: add missing `frame` argument to `NavigationMapView` initializer
-* Bump `mapbox-directions-swift` to 0.23.4 for route leg notifications support
+
+## 4.1.1 (Jul 27, 2026)
+* Bump `mapbox-directions-swift` to 0.23.4 for route leg notifications support ([#122](https://github.com/maplibre/maplibre-navigation-ios/pull/122))
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.


### PR DESCRIPTION
### Checklist

- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
- [ ] I linked any relevant issues from https://github.com/maplibre/maplibre-navigation-ios/issues

### Description

Prepare the changelog for a **4.1.1** release so consumers can pick up `mapbox-directions-swift` **0.23.4** (route leg notifications) via SPM.

### Infos for Reviewer

After merge, publish the GitHub release:
1. Tag `4.1.1` on `main`
2. Create release with notes from `CHANGELOG.md` / compare `4.1.0...4.1.1`

## Summary
- Move the directions bump into a `4.1.1` changelog section
- Enables pinning navigation SDK to `4.1.1` for leg notification support

## Test plan
- [ ] Confirm changelog section looks correct
- [ ] After merge: create tag `4.1.1` and GitHub release
- [ ] In a consumer app, bump MapboxNavigation to `4.1.1` and verify `RouteLeg.notifications` resolves

Made with [Cursor](https://cursor.com)