### PR TITLE
Bump mapbox-directions-swift to 0.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix: avoid iOS 26 name conflict
 * Fix: add missing `frame` argument to `NavigationMapView` initializer
 * Bump `mapbox-directions-swift` to 0.23.4 for route leg notifications support
+* Bump `mapbox-directions-swift` to 0.23.5 so ferry notifications without `refresh_type` parse correctly
 
 ## 3.0.0 (Jun 15, 2024)
 * The `speak` method in `RouteVoiceController` can be used without a given `RouteProgress` or the `RouteProgress` can explicitly ignored so that it will not be added to the voice instruction.

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/flitsmeister/mapbox-directions-swift",
       "state" : {
-        "revision" : "8c5b9a55a00c9ba34526bd97795d413403a602d1",
-        "version" : "0.23.4"
+        "revision" : "96a58cf55e15811b43a73c2b36d1e93bca410023",
+        "version" : "0.23.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/flitsmeister/mapbox-directions-swift", exact: "0.23.4"),
+        .package(url: "https://github.com/flitsmeister/mapbox-directions-swift", exact: "0.23.5"),
         .package(url: "https://github.com/flitsmeister/turf-swift", exact: "0.2.2"),
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.0.0"),
         .package(url: "https://github.com/ceeK/Solar.git", exact: "3.0.1"),


### PR DESCRIPTION
## Summary
- Bump Flitsmeister `mapbox-directions-swift` from `0.23.4` to `0.23.5`
- Fixes parsing of route leg notifications that omit `refresh_type` (needed for ferry notifications)

## Test plan
- [ ] SPM resolves `mapbox-directions-swift` 0.23.5
- [ ] Ferry notifications without `refresh_type` parse successfully

Made with [Cursor](https://cursor.com)